### PR TITLE
Add email copy/paste button to roster

### DIFF
--- a/csm_web/frontend/src/components/Roster.js
+++ b/csm_web/frontend/src/components/Roster.js
@@ -71,12 +71,11 @@ class Roster extends React.Component {
     return (
       <div>
         <button
-          className="uk-button uk-button-default"
-          type="button"
-          style={{ float: "right", clear: "right", width: "150px" }}
           data-uk-toggle="target: #roster-modal"
+					title="Show student roster"
+					className="show-roster-button"
         >
-          Show Roster
+					<span data-uk-icon="users"/>
         </button>
         <Modal id="roster-modal" title="Roster">
           <ul className="uk-list">{rosterEntries}</ul>

--- a/csm_web/frontend/src/components/Roster.js
+++ b/csm_web/frontend/src/components/Roster.js
@@ -5,12 +5,17 @@ import { Modal } from "../utils/common.js";
 class Roster extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { currentSectionID: props.sectionID, students: null }; // will contain entries of the form studentID: [studentName, studentEmail]
+    this.state = {
+      currentSectionID: props.sectionID,
+      students: null, // will contain entries of the form studentID: [studentName, studentEmail]
+      emailsCopied: false
+    };
+    this.handleEmailCopy = this.handleEmailCopy.bind(this);
   }
 
   static getDerivedStateFromProps(state, props) {
     if (props.sectionID !== state.currentSectionID) {
-      return { currentSectionID: props.sectionID, students: null };
+      return { currentSectionID: props.sectionID, students: null, emailsCopied: false };
     }
     return null; // does not update state
   }
@@ -40,6 +45,24 @@ class Roster extends React.Component {
         });
       });
     }
+  }
+
+  handleEmailCopy() {
+    this.setState(state =>{
+      // Be careful with this map, as we need to make sure the function arguments
+      // aren't interpreted as (value, index)
+      let emailList = Object.values(state.students).map(([_, email]) => email);
+      // Create fake textArea per https://stackoverflow.com/a/30810322
+      let clipboardElement = document.createElement("textarea");
+      clipboardElement.classList.add("clipboard-textarea");
+      clipboardElement.value = emailList.join(",");
+      document.body.appendChild(clipboardElement);
+      clipboardElement.focus();
+      clipboardElement.select();
+      let newState = { emailsCopied: document.execCommand("copy") };
+      document.body.removeChild(clipboardElement);
+      return newState;
+    });
   }
 
   componentDidMount() {
@@ -79,6 +102,19 @@ class Roster extends React.Component {
         </button>
         <Modal id="roster-modal" title="Roster">
           <ul className="uk-list">{rosterEntries}</ul>
+          <div data-uk-grid className="uk-grid-small">
+            <button className="uk-button uk-button-default uk-button-small" onClick={this.handleEmailCopy}>
+              Copy Emails
+            </button>
+            {this.state.emailsCopied && (
+              <span
+                data-uk-icon="icon: check; ratio: 1.5"
+                style={{ color: "green" }}
+              >
+                Copied to clipboard
+              </span>
+            )}
+          </div>
         </Modal>
       </div>
     );

--- a/csm_web/frontend/src/components/Section.js
+++ b/csm_web/frontend/src/components/Section.js
@@ -5,33 +5,51 @@ import Roster from "./Roster";
 import moment from "moment";
 import { fetchWithMethod, HTTP_METHODS } from "../utils/api";
 
-function SectionSummary(props) {
+function SectionHeader(props) {
   let overrideStyle = props.activeOverride
     ? "section-summary-override-flex-item"
     : "section-summary-default-flex-item";
   return (
-    <div className="uk-section uk-section-primary section-summary">
-      <div className="uk-container">
-        <div>
-          {!props.isMentor && <DropSection profileID={props.profile} />}
+    <div className="section-header">
+      {!props.isMentor && <DropSection profileID={props.profile} />}
 
-          <h2 style={{ clear: "both" }}>{props.courseName}</h2>
-          {props.isMentor && <Override sectionID={props.sectionID} />}
-          {props.isMentor && (
-            <Roster studentIDs={props.studentIDs} sectionID={props.sectionID} />
-          )}
-        </div>
-        <div className="section-summary-flex-container">
-          <p className={overrideStyle}>{props.defaultSpacetime.dayOfWeek}</p>
-          <p className={overrideStyle}>
+      <h3>{props.courseName.replace(/^(CS|EE)/, "$1 ")}</h3>
+      <div className="section-information">
+        <span title="Mentor">
+          <span className="field-icon" data-uk-icon="user" />
+          {`${props.mentor.firstName} ${props.mentor.lastName}`}
+        </span>
+        <span title="Mentor email">
+          <span className="field-icon" data-uk-icon="mail" />
+
+          <a
+            href={`mailto:${props.mentor.email}`}
+            title="Send an email to your mentor"
+          >
+            {props.mentor.email}
+          </a>
+        </span>
+
+        <span className="editable-field" title="Section time">
+          <span className="field-icon" data-uk-icon="calendar" />
+          <span className="editable-content">
+            {moment(props.defaultSpacetime.dayOfWeek, "dddd").format("ddd")}{" "}
             {props.defaultSpacetime.startTime} -{" "}
             {props.defaultSpacetime.endTime}
-          </p>
-        </div>
-        <p className={overrideStyle}>{props.defaultSpacetime.location}</p>
-        <p>{`${props.mentor.firstName} ${props.mentor.lastName}`} </p>
-        <a href={`mailto:${props.mentor.email}`}>{props.mentor.email}</a>
+          </span>
+        </span>
+        <span className="editable-field" title="Section location">
+          <span className="field-icon" data-uk-icon="location" />
+          <span className="editable-content">
+            {props.defaultSpacetime.location}
+          </span>
+        </span>
       </div>
+
+      {props.isMentor && <Override sectionID={props.sectionID} />}
+      {props.isMentor && (
+        <Roster studentIDs={props.studentIDs} sectionID={props.sectionID} />
+      )}
     </div>
   );
 }
@@ -272,14 +290,14 @@ class Section extends React.Component {
     defaultSpacetime.startTime = moment(
       defaultSpacetime.startTime,
       "HH:mm:ss"
-    ).format("hh:mm A");
+    ).format("h:mm A");
     defaultSpacetime.endTime = moment(
       defaultSpacetime.endTime,
       "HH:mm:ss"
-    ).format("hh:mm A");
+    ).format("h:mm A");
     return (
       <div>
-        <SectionSummary
+        <SectionHeader
           defaultSpacetime={defaultSpacetime}
           mentor={this.props.mentor.user}
           courseName={this.props.courseName}
@@ -304,4 +322,4 @@ class Section extends React.Component {
   }
 }
 export default Section;
-export { SectionSummary };
+export { SectionHeader };

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -197,10 +197,75 @@ html, body {
   bottom: 1em;
 }
 
+.section-header {
+	width: 100%;
+	padding: 1em;
+	background-color: #fbfbfb;
+}
+.section-header h3 {
+	margin-bottom: 0;
+	color: #373d3f;
+}
+
+.section-header .field-icon {
+	margin-right: 5px;
+}
+
+
+.section-header .section-information {
+	display: grid;
+	grid-template-columns: repeat(2, max-content);
+	grid-gap: 0px 10px;
+}
+
+@media(max-width: 500px) {
+	.section-header .section-information {
+		display: block;
+	}
+	.section-header .section-information > span {
+		display: block;
+	}
+}
+
+
+.section-header > div a {
+	color: inherit;
+}
+
+
+.section-header .editable-field .editable-content:hover {
+	outline: 2px #dedede solid;
+
+}
+
+
+
+
+
+.show-roster-button {
+	height: 36px;
+	width: 36px;
+	border-radius: 18px;
+	background-color: #ffffff;
+}
+
+.show-roster-button:focus {
+
+	background-color: #cacaca;
+	outline: none;
+
+}
+
 .section-summary-flex-container {
   display: flex;
   flex-wrap: wrap;
   align-items: baseline;
+  width: max-content;
+}
+
+.section-summary-flex-container:hover {
+	outline: #ffffff 2px solid;
+
 }
 
 .section-summary-override-flex-item {

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -204,6 +204,7 @@ html, body {
 }
 .section-header h3 {
 	margin-bottom: 0;
+	margin-top: 0px;
 	color: #373d3f;
 }
 
@@ -248,8 +249,46 @@ html, body {
 
 .section-header .editable-content:hover {
 	outline: 2px #dedede solid;
+}
+
+
+@keyframes toast-appear {
+	from {
+		right: -300px;
+	}
+
+	to {
+		right: 20px;
+	}
+}
+
+.toast {
+	position: fixed;
+	top: 100px;
+	right: 20px;
+	height: 50px;
+	z-index: 1000;
+	animation-name: toast-appear;
+	animation-duration: 0.7s;
+	box-shadow: 1px 3px 3px gray;
+	border-radius: 5px;
+	border: 1px solid #cecece;
 
 }
+
+.toast span[data-uk-icon] {
+	border-radius: 50%;
+	border: 2px solid #cccccc;
+	padding: 2px;
+	margin-right: 5px;
+}
+
+.toast > div {
+	margin: 7px 10px 0px;
+}
+
+
+
 
 
 

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -337,3 +337,17 @@ html, body {
 #show-more-btn {
   margin-left: 50%;
 }
+
+/* Invisible component used for clipboard copy/paste https://stackoverflow.com/a/30810322 */
+.clipboard-textarea {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 2em;
+  height: 2em;
+  padding: 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+}

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -232,8 +232,21 @@ html, body {
 	color: inherit;
 }
 
+.section-header .edit-buttons-container button {
 
-.section-header .editable-field .editable-content:hover {
+	width: 50px;
+	margin-right: 10px;
+	border-radius: 0px;
+	vertical-align: middle;
+	overflow: hidden;
+	background-color: #fffffe; /* border-radius doesn't work unless I set background-color to something besides #ffffff, probably a Chrome bug */
+}
+
+.section-header .edit-buttons-container {
+	
+}
+
+.section-header .editable-content:hover {
 	outline: 2px #dedede solid;
 
 }

--- a/csm_web/frontend/templates/frontend/index.html
+++ b/csm_web/frontend/templates/frontend/index.html
@@ -15,7 +15,6 @@
       href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900"
       rel="stylesheet"
     />
-
 		<!-- UIkit CSS -->
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.3/css/uikit.min.css" integrity="sha256-cnxgu1WK4uhR5pOw/YhkL1qdoVWMPceoQvv0AcIRkF0=" crossorigin="anonymous" />
     <!-- UIkit JS -->

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -131,7 +131,7 @@ class ActiveOverrideField(serializers.RelatedField):
         valid_set = overrides.filter(week_start__gte=current_week_start)
 
         # Get the one created most recently
-        first_valid_override = valid_set.order_by("week_start").first()
+        first_valid_override = valid_set.order_by("-id").first()
 
         if len(valid_set) > 0:
             return OverrideSerializer(first_valid_override).data


### PR DESCRIPTION
Adds a button that copies comma-separated student emails to the clipboard from the roster dropdown. To test, remove the `false` on line 246 of Section.js.

Copying to clipboard is harder than it sounds. See https://stackoverflow.com/a/30810322; apparently the Clipboard API isn't yet supported by some browsers.

Please make sure I didn't do anything unidiomatic lol