### PR TITLE
Small QOL/resilience fixes

### DIFF
--- a/csm_web/frontend/src/components/Attendance.js
+++ b/csm_web/frontend/src/components/Attendance.js
@@ -150,7 +150,8 @@ export class AsMentorAttendance extends React.Component {
       // Could do an ordered insert, but I'm lazy
       attendanceList.push({ date: date, attendances: attendancesByDate[date] });
     }
-    attendanceList.sort((a, b) => a.date - b.date);
+    // Display most recent on top
+    attendanceList.sort((a, b) => b.date - a.date);
     let behindOnAttendance = maxDate < lastWeekStart;
     this.state = {
       behindOnAttendance: behindOnAttendance,

--- a/csm_web/scheduler/views.py
+++ b/csm_web/scheduler/views.py
@@ -175,7 +175,7 @@ class ProfileViewSet(*viewset_with('list')):
 
     def list(self, request):
         student_profiles = StudentSerializer(request.user.student_set.filter(active=True), many=True).data
-        mentor_profiles = MentorSerializer(request.user.mentor_set.all(), many=True).data
+        mentor_profiles = MentorSerializer(request.user.mentor_set.exclude(section=None), many=True).data
         return Response({'mentor_profiles': mentor_profiles, 'student_profiles': student_profiles})
 
 


### PR DESCRIPTION
Sorts attendances so that most recent weeks are on top, and also filters Mentor profiles that have None sections on the API (I believe this caused a few 500s earlier in the semester).