### PR TITLE
Add endpoint for spacetime editing

### DIFF
--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from .models import Attendance, Course, Student, Section, Mentor, Override, Spacetime, Profile
 
 
-class SpacetimeSerializer(serializers.ModelSerializer):
+class SpacetimeReadOnlySerializer(serializers.ModelSerializer):
     time = serializers.SerializerMethodField()
 
     def get_time(self, obj):
@@ -14,6 +14,12 @@ class SpacetimeSerializer(serializers.ModelSerializer):
         model = Spacetime
         fields = ("time", "location")
         read_only_fields = ("time", "location")
+
+
+class SpacetimeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Spacetime
+        fields = ("day_of_week", "start_time", "location")
 
 
 class CourseSerializer(serializers.ModelSerializer):
@@ -35,7 +41,7 @@ class CourseSerializer(serializers.ModelSerializer):
 class ProfileSerializer(serializers.Serializer):
     id = serializers.IntegerField()
     section_id = serializers.IntegerField(source='section.id')
-    section_spacetime = SpacetimeSerializer(source='section.spacetime')
+    section_spacetime = SpacetimeReadOnlySerializer(source='section.spacetime')
     course = serializers.CharField(source='section.course.name')
     course_title = serializers.CharField(source='section.course.title')
     is_student = serializers.SerializerMethodField()
@@ -73,7 +79,7 @@ class StudentSerializer(serializers.ModelSerializer):
 
 
 class OverrideReadOnlySerializer(serializers.ModelSerializer):
-    spacetime = SpacetimeSerializer()
+    spacetime = SpacetimeReadOnlySerializer()
     date = serializers.DateField(format="%b. %-d")
 
     class Meta:
@@ -83,7 +89,7 @@ class OverrideReadOnlySerializer(serializers.ModelSerializer):
 
 
 class SectionSerializer(serializers.ModelSerializer):
-    spacetime = SpacetimeSerializer()
+    spacetime = SpacetimeReadOnlySerializer()
     num_students_enrolled = serializers.IntegerField(source='current_student_count')
     mentor = MentorSerializer()
     course = serializers.CharField(source='course.name')

--- a/csm_web/scheduler/views.py
+++ b/csm_web/scheduler/views.py
@@ -1,19 +1,26 @@
-from django.shortcuts import get_object_or_404
-from django.db import transaction
-from django.db.models.query import EmptyQuerySet
-from django.utils import timezone
-from rest_framework import viewsets
-from rest_framework.decorators import action
-from rest_framework.response import Response
-from rest_framework import status
-from rest_framework.exceptions import PermissionDenied
-from .models import Course, Section, Student, Spacetime, User, Override, Attendance
-from rest_framework import mixins
-from .serializers import CourseSerializer, SectionSerializer, StudentSerializer, AttendanceSerializer, MentorSerializer, OverrideSerializer, ProfileSerializer
-from django.core.exceptions import ObjectDoesNotExist
-from operator import attrgetter
 from itertools import groupby
 import logging
+from operator import attrgetter
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
+from django.db.models.query import EmptyQuerySet
+from django.shortcuts import get_object_or_404
+from django.utils import timezone
+from rest_framework import mixins, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.exceptions import PermissionDenied
+from .models import Course, Section, Student, Spacetime, User, Override, Attendance
+from .serializers import (
+    CourseSerializer,
+    SectionSerializer,
+    StudentSerializer,
+    AttendanceSerializer,
+    MentorSerializer,
+    OverrideSerializer,
+    ProfileSerializer,
+    SpacetimeSerializer
+)
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +190,20 @@ class SpacetimeViewSet(viewsets.GenericViewSet):
 
     def get_queryset(self):
         return Spacetime.objects.filter(section__mentor__user=self.request.user)
+
+    @action(detail=True, methods=['put'])
+    def modify(self, request, pk=None):
+        """Permanently modifies a spacetime, ignoring the override field."""
+        spacetime = get_object_or_error(self.get_queryset(), pk=pk)
+        serializer = SpacetimeSerializer(spacetime, data=request.data)
+        if serializer.is_valid():
+            new_spacetime = serializer.save()
+            logger.info(
+                f"<Spacetime:Success> Modified Spacetime {log_str(new_spacetime)} (previously {log_str(spacetime)})")
+            return Response(status=status.HTTP_202_ACCEPTED)
+        logger.error(
+            f"<Spacetime:Failure> Could not modify Spacetime {log_str(spacetime)}, errors: {serializer.errors}")
+        return Response(serializer.errors, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     @action(detail=True, methods=['put'])
     def override(self, request, pk=None):


### PR DESCRIPTION
Here's an endpoint that lets you edit spacetimes. I wasn't able to test it manually because I ran into some CSRF problems I didn't have time to figure out, so I wrote a test case instead.

A couple other things I noticed while making this:
- Our tests definitely have race conditions somewhere. After deleting the `test_enroll_drop` to see if the other tests passed, some runs would give 4 failures and others 3 without any changes occurring in between.
- DRF's @action annotation allows GET methods by default ("The action decorator will route GET requests by default, but may also accept other HTTP methods by setting the methods argument." https://www.django-rest-framework.org/api-guide/viewsets/#marking-extra-actions-for-routing). Visiting `/spacetimes/:pk/modify/` or `/spacetimes/:pk/override/` evidences that specifying actions does not remove GET. I haven't looked into how to get it to not route GET; hopefully there's a way.