### PR TITLE
Performance enhancements for /courses/$pk/sections endpoint

### DIFF
--- a/csm_web/csm_web/settings.py
+++ b/csm_web/csm_web/settings.py
@@ -104,8 +104,10 @@ WSGI_APPLICATION = "csm_web.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
+DEV_USE_POSTGRES = os.environ.get("DEV_USE_POSTGRES")
+
 if DEBUG:
-    if os.environ.get("DEV_USE_POSTGRES"):
+    if DEV_USE_POSTGRES:
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.postgresql',

--- a/csm_web/csm_web/settings.py
+++ b/csm_web/csm_web/settings.py
@@ -104,14 +104,25 @@ WSGI_APPLICATION = "csm_web.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
-    }
-}
-
-if not DEBUG:
+if DEBUG:
+    if os.environ.get("DEV_USE_POSTGRES"):
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.postgresql',
+                'NAME': 'csm_web_dev',
+                'USER': 'postgres',
+                'HOST': 'localhost',
+                'PORT': '5432',
+            }
+        }
+    else:
+        DATABASES = {
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
+            }
+        }
+else:
     DATABASES["pg"] = {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": "csm_web",

--- a/csm_web/csm_web/settings.py
+++ b/csm_web/csm_web/settings.py
@@ -125,13 +125,15 @@ if DEBUG:
             }
         }
 else:
-    DATABASES["pg"] = {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": "csm_web",
-        "USER": "csm_web",
-        "PASSWORD": "",
-        "HOST": "localhost",
-        "PORT": "",
+    DATABASES = {
+        "pg": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": "csm_web",
+            "USER": "csm_web",
+            "PASSWORD": "",
+            "HOST": "localhost",
+            "PORT": "",
+        }
     }
 
 

--- a/csm_web/csm_web/settings.py
+++ b/csm_web/csm_web/settings.py
@@ -104,10 +104,8 @@ WSGI_APPLICATION = "csm_web.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
-DEV_USE_POSTGRES = os.environ.get("DEV_USE_POSTGRES")
-
 if DEBUG:
-    if DEV_USE_POSTGRES:
+    if os.environ.get("DEV_USE_POSTGRES"):
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.postgresql',

--- a/csm_web/scheduler/models.py
+++ b/csm_web/scheduler/models.py
@@ -3,7 +3,7 @@ import re
 from django.db import models
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
-from django.utils import timezone
+from django.utils import timezone, functional
 from rest_framework.serializers import ValidationError
 
 
@@ -145,11 +145,9 @@ class Section(ValidatingModel):
         '"early start".'
     )
 
-    @property
+    @functional.cached_property
     def current_student_count(self):
         return self.students.filter(active=True).count()
-
-    current_student_count.fget.short_description = "Number of students enrolled"
 
     def delete(self, *args, **kwargs):
         if self.current_student_count and not kwargs.get('force'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ isort==4.3.21
 lazy-object-proxy==1.4.2
 mccabe==0.6.1
 oauthlib==3.1.0
-psycopg2==2.7.7
+psycopg2-binary==2.8.4
 PyJWT==1.7.1
 pylint==2.3.1
 pylint-django==2.0.11


### PR DESCRIPTION
The `/courses/$pk/sections` endpoint was *painfully* slow for courses with more than a handful of sections (taking 2-3 seconds to respond in production). I've optimized this to make it 2-3 times faster on average by making more intelligent use of the database. The increased efficiency should not only help reduce server strain during enrollment as this is easily our heaviest endpoint, but also improves QOL for coordinators as they access this endpoint regularly.