### PR TITLE
Efficient patchattendances

### DIFF
--- a/csm_web/scheduler/management/commands/patchattendances.py
+++ b/csm_web/scheduler/management/commands/patchattendances.py
@@ -10,8 +10,8 @@ class Command(BaseCommand):
         today = date.today()
         week_start = today - timedelta(days=today.weekday())
         week_end = week_start + timedelta(weeks=1)
-        students = Student.objects.filter(active=True).only(
-            "id").exclude(attendance__date__range=(week_start, week_end))
+        students = Student.objects.filter(active=True).select_related(
+            "section__course", "user") .exclude(attendance__date__range=(week_start, week_end))
         # Note that bulk_create can only set the primary key in Postgres, so this won't work as expected in development if using Sqlite
         print(f"Updating attendance for week of {week_start}")
         print('\n'.join(map(str, students)))

--- a/csm_web/scheduler/management/commands/patchattendances.py
+++ b/csm_web/scheduler/management/commands/patchattendances.py
@@ -13,4 +13,6 @@ class Command(BaseCommand):
         students = Student.objects.filter(active=True).only(
             "id").exclude(attendance__date__range=(week_start, week_end))
         # Note that bulk_create can only set the primary key in Postgres, so this won't work as expected in development if using Sqlite
+        print(f"Updating attendance for week of {week_start}")
+        print('\n'.join(map(str, students)))
         Attendance.objects.bulk_create(Attendance(student=student, date=week_start) for student in students)


### PR DESCRIPTION
I want to run `manage.py patchattendances` every hour so that we stop getting questions from confused mentors about the roster/attendance mismatch, but the previous implementation was so inefficient in the number of database queries it performed and the locks it held I didn't feel comfortable running it during the day while people were using the application. This PR fixes that.