### PR TITLE
Halve latency on direct navigation to course enrollment/management

### DIFF
--- a/csm_web/frontend/src/components/CourseMenu.js
+++ b/csm_web/frontend/src/components/CourseMenu.js
@@ -22,28 +22,32 @@ export default class CourseMenu extends React.Component {
   render() {
     const { path } = this.props.match;
     const { loaded, courses } = this.state;
-    return !loaded ? (
-      <div>Loading...</div>
-    ) : (
+    return (
       <Switch>
         <Route
           path="/courses/:id"
-          render={routeProps => <Course name={courses[routeProps.match.params.id].name} {...routeProps} />}
+          render={routeProps => (
+            <Course name={loaded && courses[routeProps.match.params.id].name} {...routeProps} />
+          )}
         />
         <Route
           path="/courses"
-          render={() => (
-            <React.Fragment>
-              <h3 className="page-title center-title">Which course would you like to enroll in?</h3>
-              <div id="course-menu">
-                {Object.entries(courses).map(([id, { name }]) => (
-                  <Link className="csm-btn" to={`${path}/${id}`} key={id}>
-                    {name}
-                  </Link>
-                ))}
-              </div>
-            </React.Fragment>
-          )}
+          render={() =>
+            !loaded ? (
+              <div>Loading...</div>
+            ) : (
+              <React.Fragment>
+                <h3 className="page-title center-title">Which course would you like to enroll in?</h3>
+                <div id="course-menu">
+                  {Object.entries(courses).map(([id, { name }]) => (
+                    <Link className="csm-btn" to={`${path}/${id}`} key={id}>
+                      {name}
+                    </Link>
+                  ))}
+                </div>
+              </React.Fragment>
+            )
+          }
         />
       </Switch>
     );


### PR DESCRIPTION
I realized there was an unnecessary 'waterfall' where when you navigated _directly_ to the course enrollment/management page (either by clicking a "coordinator" card or refreshing the enrollment page as a student) causing users to wait for two roundtrips to the API for requests that could be made in parallel. 