### PR TITLE
Autofill spacetime on override modal

### DIFF
--- a/csm_web/frontend/src/components/MentorSection.js
+++ b/csm_web/frontend/src/components/MentorSection.js
@@ -298,11 +298,14 @@ class SpacetimeEditModal extends React.Component {
   constructor(props) {
     super(props);
     // Time string comes as HH:MM:ss, TimeInput expects HH:MM
-    let timeString = props.defaultSpacetime.startTime;
+    const timeString = props.defaultSpacetime.startTime;
+    // Some extra logic in case the API changes to HH:MM,
+    // in which case split would produce 2 segments instead of 3
+    const sliceIndex = timeString.split(":").length < 3 ? timeString.indexOf(":") : timeString.lastIndexOf(":");
     this.state = {
       location: props.defaultSpacetime.location,
       day: props.defaultSpacetime.dayOfWeek,
-      time: timeString.slice(0, timeString.lastIndexOf(":")),
+      time: timeString.slice(0, sliceIndex),
       isPermanent: false,
       changeDate: "",
       mode: "inperson",
@@ -314,7 +317,6 @@ class SpacetimeEditModal extends React.Component {
 
   static propTypes = {
     closeModal: PropTypes.func.isRequired,
-    spacetimeId: PropTypes.number.isRequired,
     defaultSpacetime: SPACETIME_SHAPE.isRequired,
     reloadSection: PropTypes.func.isRequired
   };
@@ -325,7 +327,8 @@ class SpacetimeEditModal extends React.Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    const { closeModal, spacetimeId, reloadSection } = this.props;
+    const { closeModal, defaultSpacetime, reloadSection } = this.props;
+    const spacetimeId = defaultSpacetime.id;
     let { location, day, time, isPermanent, changeDate } = this.state;
     isPermanent = !!isPermanent;
     //TODO: Handle API failure
@@ -591,12 +594,7 @@ function MentorSectionInfo({
         </InfoCard>
         <SectionSpacetime spacetime={spacetime} override={override}>
           {showModal === MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT && (
-            <SpacetimeEditModal
-              reloadSection={reloadSection}
-              spacetimeId={spacetime.id}
-              defaultSpacetime={spacetime}
-              closeModal={closeModal}
-            />
+            <SpacetimeEditModal reloadSection={reloadSection} defaultSpacetime={spacetime} closeModal={closeModal} />
           )}
           <button
             className="info-card-edit-btn"

--- a/csm_web/frontend/src/components/MentorSection.js
+++ b/csm_web/frontend/src/components/MentorSection.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { fetchJSON, fetchWithMethod, HTTP_METHODS } from "../utils/api";
+import { SPACETIME_SHAPE } from "../utils/types";
 import { SectionDetail, InfoCard, SectionSpacetime, ROLES } from "./Section";
 import { Switch, Route } from "react-router-dom";
 import { groupBy } from "lodash";
@@ -296,10 +297,12 @@ function zeroPadTwoDigit(num) {
 class SpacetimeEditModal extends React.Component {
   constructor(props) {
     super(props);
+    // Time string comes as HH:MM:ss, TimeInput expects HH:MM
+    let timeString = props.defaultSpacetime.startTime;
     this.state = {
-      location: "",
-      day: "",
-      time: "",
+      location: props.defaultSpacetime.location,
+      day: props.defaultSpacetime.dayOfWeek,
+      time: timeString.slice(0, timeString.lastIndexOf(":")),
       isPermanent: false,
       changeDate: "",
       mode: "inperson",
@@ -312,6 +315,7 @@ class SpacetimeEditModal extends React.Component {
   static propTypes = {
     closeModal: PropTypes.func.isRequired,
     spacetimeId: PropTypes.number.isRequired,
+    defaultSpacetime: SPACETIME_SHAPE.isRequired,
     reloadSection: PropTypes.func.isRequired
   };
 
@@ -587,7 +591,12 @@ function MentorSectionInfo({
         </InfoCard>
         <SectionSpacetime spacetime={spacetime} override={override}>
           {showModal === MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT && (
-            <SpacetimeEditModal reloadSection={reloadSection} spacetimeId={spacetime.id} closeModal={closeModal} />
+            <SpacetimeEditModal
+              reloadSection={reloadSection}
+              spacetimeId={spacetime.id}
+              defaultSpacetime={spacetime}
+              closeModal={closeModal}
+            />
           )}
           <button
             className="info-card-edit-btn"

--- a/csm_web/frontend/src/utils/types.js
+++ b/csm_web/frontend/src/utils/types.js
@@ -1,5 +1,9 @@
 import PropTypes from "prop-types";
 export const SPACETIME_SHAPE = PropTypes.shape({
+  dayOfWeek: PropTypes.string.isRequired,
+  duration: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
   location: PropTypes.string.isRequired,
+  startTime: PropTypes.string.isRequired,
   time: PropTypes.string.isRequired
 });


### PR DESCRIPTION
Implements one of the changes in #164. I tested this in both 24-hr and 12-hr display in both Chrome and Safari, so hopefully it works.

I noticed that the definition of `SPACETIME_SHAPE` seems to have a lot of fields missing - is this supposed to be the case, or are the fields just initialized late? If the former is the case then I'll fix the fields in this PR as well.