### PR TITLE
Multiple sections attendance fix

### DIFF
--- a/csm_web/frontend/src/components/MentorSection.js
+++ b/csm_web/frontend/src/components/MentorSection.js
@@ -36,17 +36,17 @@ export default function MentorSection({
             attendances.map(attendance => ({ ...attendance, student: { name, id } }))
           )
           .reverse(),
-        attendance => attendance.weekStart
+        attendance => attendance.date
       );
       setState({ students, attendances, loaded: true });
     });
   }, [id]);
 
-  const updateAttendance = (updatedWeek, updatedWeekAttendances) => {
+  const updateAttendance = (updatedDate, updatedDateAttendances) => {
     const updatedAttendances = Object.fromEntries(
-      Object.entries(attendances).map(([weekStart, weekAttendances]) => [
-        weekStart,
-        weekStart == updatedWeek ? [...updatedWeekAttendances] : weekAttendances
+      Object.entries(attendances).map(([date, dateAttendances]) => [
+        date,
+        date == updatedDate ? [...updatedDateAttendances] : dateAttendances
       ])
     );
     setState({ students, loaded, attendances: updatedAttendances });
@@ -150,7 +150,7 @@ class MentorSectionAttendance extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedWeek: null,
+      selectedDate: null,
       stagedAttendances: null,
       showAttendanceSaveSuccess: false,
       showSaveSpinner: false
@@ -179,7 +179,7 @@ class MentorSectionAttendance extends React.Component {
   }
 
   handleSaveAttendance() {
-    const { stagedAttendances, selectedWeek } = this.state;
+    const { stagedAttendances, selectedDate } = this.state;
     if (!stagedAttendances) {
       return;
     }
@@ -190,7 +190,7 @@ class MentorSectionAttendance extends React.Component {
         fetchWithMethod(`students/${studentId}/attendances/`, HTTP_METHODS.PUT, { id, presence })
       )
     ).then(() => {
-      this.props.updateAttendance(selectedWeek, stagedAttendances);
+      this.props.updateAttendance(selectedDate, stagedAttendances);
       this.setState({ showAttendanceSaveSuccess: true, showSaveSpinner: false });
       setTimeout(() => this.setState({ showAttendanceSaveSuccess: false }), 1500);
     });
@@ -198,8 +198,8 @@ class MentorSectionAttendance extends React.Component {
 
   handleMarkAllPresent() {
     if (!this.state.stagedAttendances) {
-      const [selectedWeek, stagedAttendances] = Object.entries(this.props.attendances)[0];
-      this.setState({ selectedWeek, stagedAttendances });
+      const [selectedDate, stagedAttendances] = Object.entries(this.props.attendances)[0];
+      this.setState({ selectedDate, stagedAttendances });
     }
     this.setState(prevState => ({
       stagedAttendances: prevState.stagedAttendances.map(attendance => ({ ...attendance, presence: "PR" }))
@@ -208,8 +208,8 @@ class MentorSectionAttendance extends React.Component {
 
   render() {
     const { attendances, loaded } = this.props;
-    const selectedWeek = this.state.selectedWeek || (loaded && Object.keys(attendances)[0]);
-    const stagedAttendances = this.state.stagedAttendances || attendances[selectedWeek];
+    const selectedDate = this.state.selectedDate || (loaded && Object.keys(attendances)[0]);
+    const stagedAttendances = this.state.stagedAttendances || attendances[selectedDate];
     const { showAttendanceSaveSuccess, showSaveSpinner } = this.state;
     return (
       <React.Fragment>
@@ -220,21 +220,19 @@ class MentorSectionAttendance extends React.Component {
           <React.Fragment>
             <div id="mentor-attendance">
               <div id="attendance-date-tabs-container">
-                {Object.keys(attendances).map(weekStart => (
+                {Object.keys(attendances).map(date => (
                   <div
-                    key={weekStart}
-                    className={weekStart === selectedWeek ? "active" : ""}
-                    onClick={() =>
-                      this.setState({ selectedWeek: weekStart, stagedAttendances: attendances[weekStart] })
-                    }
+                    key={date}
+                    className={date === selectedDate ? "active" : ""}
+                    onClick={() => this.setState({ selectedDate: date, stagedAttendances: attendances[date] })}
                   >
-                    {formatDate(weekStart)}
+                    {formatDate(date)}
                   </div>
                 ))}
               </div>
               <table id="mentor-attendance-table">
                 <tbody>
-                  {selectedWeek &&
+                  {selectedDate &&
                     stagedAttendances.map(({ id, student, presence }) => (
                       <tr key={id}>
                         <td>{student.name}</td>

--- a/csm_web/frontend/src/components/StudentSection.js
+++ b/csm_web/frontend/src/components/StudentSection.js
@@ -148,16 +148,16 @@ function StudentSectionAttendance({ associatedProfileId }) {
     <table id="attendance-table" className="standalone-table">
       <thead>
         <tr>
-          <th>Week</th>
+          <th>Date</th>
           <th>Status</th>
         </tr>
       </thead>
       <tbody>
-        {attendances.map(({ presence, weekStart }) => {
+        {attendances.map(({ presence, date }) => {
           const [label, cssSuffix] = ATTENDANCE_LABELS[presence];
           return (
-            <tr key={weekStart}>
-              <td>{weekStart}</td>
+            <tr key={date}>
+              <td>{date}</td>
               <td className="status">
                 <div style={{ backgroundColor: `var(--csm-attendance-${cssSuffix})` }}>{label}</div>
               </td>

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -125,12 +125,12 @@ class MentorSerializer(serializers.ModelSerializer):
 
 
 class AttendanceSerializer(serializers.ModelSerializer):
-    week_start = serializers.DateField(format="%b. %-d, %Y", read_only=True)
+    date = serializers.DateField(format="%b. %-d, %Y", read_only=True)
 
     class Meta:
         model = Attendance
-        fields = ("id", "presence", "week_start", "student")
-        read_only_fields = ("week_start",)
+        fields = ("id", "presence", "date", "student")
+        read_only_fields = ("date",)
         extra_kwargs = {'student': {'write_only': True}}
 
 


### PR DESCRIPTION
Attendance now generated correctly for sections that meet more than once-per-week.

There is a quirk, consider this example: if a student drops a section that met on **Monday**  after attending it for the first time, and then signs up for a different section in the same course that meets on **Wednesday**, **both** attendances will be shown to the mentor of the latter section (i.e. the section the student is now enrolled in) despite the fact their section doesn't meet on Mondays. While this might be potentially confusing to Mentors (and possibly should be remedied on the frontend later on), I think this is the correct thing to do on the backend, as we want to know if a student didn't attend their initial section for the sake of P/NP or banning them if it was the first week of sections.

`manage.py patchattendances` has **not** been fixed yet, will come in a later PR.
