### PR TITLE
Add dark-mode option under a toggle button

### DIFF
--- a/csm_web/frontend/src/components/App.js
+++ b/csm_web/frontend/src/components/App.js
@@ -9,7 +9,10 @@ import LogoNoText from "../../static/frontend/img/logo_no_text.svg";
 import LogOutIcon from "../../static/frontend/img/log_out.svg";
 
 export default class App extends React.Component {
-  state = { error: null };
+  state = {
+    error: null,
+    isDarkMode: window.localStorage.getItem("darkMode") == "true"
+  };
 
   static getDerivedStateFromError(error) {
     return { error };
@@ -25,8 +28,14 @@ export default class App extends React.Component {
     }
     return (
       <Router>
-        <React.Fragment>
-          <Header />
+        <div className={`theme-base ${this.state.isDarkMode ? "theme-dark" : "theme-light"}`}>
+          <Header
+            isDarkMode={this.state.isDarkMode}
+            setDarkMode={mode => {
+              window.localStorage.setItem("darkMode", mode);
+              this.setState({ isDarkMode: mode });
+            }}
+          />
           <main>
             <Switch>
               <Route exact path="/" component={Home} />
@@ -34,24 +43,13 @@ export default class App extends React.Component {
               <Route path="/courses" component={CourseMenu} />
             </Switch>
           </main>
-        </React.Fragment>
+        </div>
       </Router>
     );
   }
 }
 
-const applyDarkMode = isDarkMode => {
-  window.localStorage.setItem("darkMode", isDarkMode);
-  document.getElementById("app").className = isDarkMode ? "dark-mode" : "";
-  document.body.style.backgroundColor = isDarkMode ? "#1c1d1e" : "white";
-};
-
-function Header() {
-  const [isDarkMode, setDarkMode] = React.useState(window.localStorage.getItem("darkMode") == "true");
-  React.useEffect(() => {
-    applyDarkMode(isDarkMode);
-  }, [isDarkMode]);
-
+function Header({ isDarkMode, setDarkMode }) {
   return (
     <header>
       <Link to="/">
@@ -72,6 +70,11 @@ function Header() {
     </header>
   );
 }
+
+Header.propTypes = {
+  isDarkMode: PropTypes.bool.isRequired,
+  setDarkMode: PropTypes.func.isRequired
+};
 
 function ErrorPage({ error: { message, stack }, clearError }) {
   useEffect(() => {
@@ -113,9 +116,4 @@ ErrorPage.propTypes = {
 };
 
 const wrapper = document.getElementById("app");
-wrapper
-  ? (() => {
-      applyDarkMode(window.localStorage.getItem("darkMode") == "true");
-      ReactDOM.render(<App />, wrapper);
-    })()
-  : null;
+wrapper ? ReactDOM.render(<App />, wrapper) : null;

--- a/csm_web/frontend/src/components/App.js
+++ b/csm_web/frontend/src/components/App.js
@@ -40,13 +40,32 @@ export default class App extends React.Component {
   }
 }
 
+const applyDarkMode = isDarkMode => {
+  window.localStorage.setItem("darkMode", isDarkMode);
+  document.getElementById("app").className = isDarkMode ? "dark-mode" : "";
+  document.body.style.backgroundColor = isDarkMode ? "#1c1d1e" : "white";
+};
+
 function Header() {
+  const [isDarkMode, setDarkMode] = React.useState(window.localStorage.getItem("darkMode") == "true");
+  React.useEffect(() => {
+    applyDarkMode(isDarkMode);
+  }, [isDarkMode]);
+
   return (
     <header>
       <Link to="/">
         <LogoNoText id="logo" />
       </Link>
       <h3 id="site-title">Scheduler</h3>
+      <button
+        id="dark-mode"
+        onClick={() => {
+          setDarkMode(!isDarkMode);
+        }}
+      >
+        {isDarkMode ? "Disable Dark Mode" : "Enable Dark Mode"}
+      </button>
       <a id="logout-btn" href="/logout" title="Log out">
         <LogOutIcon width="1.25em" height="1.25em" />
       </a>
@@ -94,4 +113,9 @@ ErrorPage.propTypes = {
 };
 
 const wrapper = document.getElementById("app");
-wrapper ? ReactDOM.render(<App />, wrapper) : null;
+wrapper
+  ? (() => {
+      applyDarkMode(window.localStorage.getItem("darkMode") == "true");
+      ReactDOM.render(<App />, wrapper);
+    })()
+  : null;

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -13,6 +13,10 @@ body {
 }
 
 #app {
+	height: 100%;
+}
+
+.theme-base {
 	--csm-background: #ffffff;
 	--csm-text: #808080;
 	--csm-text-bold: #000000;
@@ -37,7 +41,7 @@ body {
 	--csm-card-background: #ffffff;
 }
 
-#app.dark-mode {
+.theme-dark {
 	--csm-background: #1c1d1e;
 	--csm-text: #ffffff;
 	--csm-text-bold: #ffffff;
@@ -46,14 +50,14 @@ body {
 }
 
 /* split out from variables for cleanliness */
-#app {
+.theme-base {
 	background-color: var(--csm-background);
 	color: var(--csm-text);
 	min-height: 100%;
 	transition: color 0.25s, background-color 0.25s;
 }
 
-#app a {
+.theme-base a {
 	color: var(--csm-link-color);
 }
 
@@ -386,7 +390,7 @@ header {
 	background-color: #eaeaea;
 }
 
-.dark-mode .section-card.full {
+.theme-dark .section-card.full {
 	background-color: initial;
 	opacity: 35%;
 }
@@ -408,7 +412,7 @@ header {
 	transition: filter 0.25s;
 }
 
-.dark-mode .section-card-contents svg {
+.theme-dark .section-card-contents svg {
 	filter: invert(100%);
 }
 
@@ -858,7 +862,7 @@ table tbody tr:last-child > td {
 	text-decoration: none;
 }
 
-.dark-mode #section-detail-sidebar a {
+.theme-dark #section-detail-sidebar a {
 	color: #818181;
 }
 

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -7,11 +7,15 @@ body {
 
 body {
 	max-width: 100%;
-	margin: 8px; /* Usually set by browser stylesheet, but we standardize it here to account for different browsers */
+	/* Usually set by browser stylesheet, but we standardize it here to account for different browsers */
+	margin: 8px 0px;
 	overflow-x: hidden;
 }
 
-:root {
+#app {
+	--csm-background: #ffffff;
+	--csm-text: #808080;
+	--csm-text-bold: #000000;
 	--csm-green: #9ae0b3;
 	--csm-green-darkened: #88cea1;
 	--csm-theme-cs61a: var(--csm-green);
@@ -29,6 +33,28 @@ body {
 	--csm-danger: #ff7272;
 	--csm-danger-darkened: #eb6060;
 	--csm-neutral: #c0c0c0;
+	--csm-link-color: #0000ff;
+	--csm-card-background: #ffffff;
+}
+
+#app.dark-mode {
+	--csm-background: #1c1d1e;
+	--csm-text: #ffffff;
+	--csm-text-bold: #ffffff;
+	--csm-link-color: #63c5ff;
+	--csm-card-background: #222222;
+}
+
+/* split out from variables for cleanliness */
+#app {
+	background-color: var(--csm-background);
+	color: var(--csm-text);
+	min-height: 100%;
+	transition: color 0.25s, background-color 0.25s;
+}
+
+#app a {
+	color: var(--csm-link-color);
 }
 
 /* Header */
@@ -49,7 +75,8 @@ header {
 	font-weight: 600;
 	font-size: 23px;
 	line-height: 18px;
-	color: #808080;
+	color: var(--csm-text);
+	transition: color 0.25s;
 }
 
 #user-profile-pic {
@@ -59,13 +86,30 @@ header {
 	box-shadow: 0px 4px 4px rgba(136, 136, 136, 0.25);
 }
 
-#logout-btn {
+#dark-mode {
 	margin: auto 0 auto auto;
+	background-color: var(--csm-card-background);
+	color: var(--csm-text-bold);
+	border: 1px solid var(--csm-text);
+	font-size: 17px;
+	border-radius: 5px;
+	padding: 12px;
+	outline: 0;
+	transition: color 0.25s, background-color 0.25s;
+}
+
+#dark-mode:hover {
+	background-color: rgba(196, 196, 196, 0.28);
+}
+
+#logout-btn {
+	margin: auto 0 auto 10px;
 }
 
 #logout-btn * {
-	fill: #808080;
+	fill: var(--csm-text);
 	vertical-align: middle;
+	transition: fill 0.25s;
 }
 
 #logout-btn:hover * {
@@ -82,8 +126,9 @@ header {
 	height: 400px;
 	max-height: 90vh;
 	z-index: 1000;
-	background-color: white;
+	background-color: var(--csm-card-background);
 	border-radius: 20px;
+	transition: background-color 0.25s;
 }
 
 .modal-overlay {
@@ -114,8 +159,9 @@ header {
 
 .modal-contents h3 {
 	text-align: center;
-	color: #808080;
+	color: var(--csm-text);
 	font-size: 2em;
+	transition: color 0.25s;
 }
 
 .modal-contents h4 {
@@ -189,7 +235,7 @@ header {
 .csm-btn {
 	background-color: var(--csm-green);
 	border-radius: 20px;
-	color: white;
+	color: white !important;
 	padding: 3px 10px;
 	text-decoration: none;
 	/* Need to manually respecify this on <buttons> for some strange reason */
@@ -209,11 +255,15 @@ header {
 	min-height: 180px;
 	border-top: 30px solid;
 	border-top-color: red;
+	background-color: var(--csm-card-background);
+	transition: background-color 0.25s;
 }
 
 .course-cards-container > .course-card,
 .course-card-link {
 	margin: 0 75px 50px 0;
+	color: var(--csm-text-bold);
+	transition: color 0.25s;
 }
 
 .course-card-contents {
@@ -233,6 +283,8 @@ header {
 	margin: 0;
 	font-size: 24px;
 	font-weight: bold;
+	color: var(--csm-text-bold);
+	transform: color 0.25s;
 }
 
 .course-card-section-time:not(:last-of-type)::after {
@@ -244,7 +296,8 @@ header {
 .course-card-title {
 	margin: 0 0 20px;
 	font-size: 14px;
-	color: #bfbfbf;
+	color: var(--csm-text);
+	transition: color 0.25s;
 }
 
 .course-cards-container {
@@ -266,9 +319,10 @@ header {
 }
 
 .course-card-link {
-	color: unset;
+	color: var(--csm-text-bold);
 	text-decoration: none;
 	cursor: pointer;
+	transition: color 0.25s;
 }
 
 .course-card-link:hover > .course-card {
@@ -276,12 +330,13 @@ header {
 }
 
 .section-link {
-	color: unset;
+	color: var(--csm-text-bold);
 	text-decoration: none;
 	cursor: pointer;
 	padding: 10px;
 	font-size: 14px;
 	border-radius: 9px;
+	transition: color 0.25s;
 }
 
 .section-link:hover {
@@ -322,11 +377,18 @@ header {
 	overflow-x: hidden;
 	box-shadow: 0px 5px 50px rgba(0, 0, 0, 0.15);
 	border-radius: 20px;
+	background-color: var(--csm-card-background);
 	margin: 0 auto 50px;
+	transition: background-color 0.25s;
 }
 
 .section-card.full {
 	background-color: #eaeaea;
+}
+
+.dark-mode .section-card.full {
+	background-color: initial;
+	opacity: 35%;
 }
 
 .section-card-contents {
@@ -335,13 +397,19 @@ header {
 }
 
 .section-card-contents p {
-	color: #727272;
+	color: var(--csm-text);
+	transition: color 0.25s;
 }
 
 .section-card-contents svg,
 .section-card-icon-placeholder {
 	vertical-align: bottom;
 	margin-right: 5px;
+	transition: filter 0.25s;
+}
+
+.dark-mode .section-card-contents svg {
+	filter: invert(100%);
 }
 
 .section-card-additional-times {
@@ -403,16 +471,18 @@ header {
 }
 
 .course-title {
-	color: #6d6d6d;
+	color: var(--csm-text);
 	font-size: 2.5em;
 	font-weight: 400;
 	text-align: center;
+	transition: color 0.25s;
 }
 
 #show-unavailable-toggle {
 	display: block;
 	text-align: center;
-	color: #727272;
+	color: var(--csm-text);
+	transition: color 0.25s;
 }
 
 #show-unavailable-toggle > input {
@@ -448,8 +518,9 @@ header {
 
 #course-section-list-empty {
 	width: 300px; /* Match width of section card so day selector stays stationary */
-	color: #646464;
+	color: var(--csm-text);
 	text-align: center;
+	transition: color 0.25s;
 }
 
 #course-section-selector {
@@ -483,9 +554,10 @@ header {
 
 #create-section-form-contents > .spacetime-fields-header {
 	margin: 0 0 10px 0;
-	color: #646464;
+	color: var(--csm-text);
 	min-width: 100%;
 	border-bottom: 2px solid #646464;
+	transition: color 0.25s;
 }
 
 #create-section-form-contents {
@@ -589,7 +661,8 @@ header {
 	font-style: normal;
 	font-weight: bold;
 	font-size: 24px;
-	color: #646464;
+	color: var(--csm-text-bold);
+	transition: color 0.25s;
 }
 
 .center-title {
@@ -617,23 +690,27 @@ main {
 }
 
 .section-detail-header-title > h3 {
+	color: var(--csm-text-bold);
 	font-size: 30px;
 	margin: 0 20px 0 0;
 	line-height: 30px;
+	transition: color 0.25s;
 }
 
 .section-detail-header-title > h4 {
-	color: #bfbfbf;
+	color: var(--csm-text);
 	font-size: 25px;
 	font-weight: normal;
 	margin: 0;
+	transition: color 0.25s;
 }
 
 .section-detail-page-title {
-	color: #646464;
+	color: var(--csm-text);
 	font-size: 30px;
 	font-weight: bold;
 	margin: 0 0 45px;
+	transition: color 0.25s;
 }
 
 .section-info-cards-container {
@@ -646,10 +723,11 @@ main {
 }
 
 .section-detail-info-card h4 {
-	color: #646464;
+	color: var(--csm-text);
 	font-size: 25px;
 	font-weight: bold;
 	margin: 0 0 20px;
+	transition: color 0.25s;
 }
 
 .section-detail-info-card.drop-section {
@@ -714,8 +792,9 @@ main {
 
 .section-detail-info-card-contents h5 {
 	font-size: 25px;
-	color: #727070;
+	color: var(--csm-text-bold);
 	margin: 0 auto 0.5em auto;
+	transform: color 0.25s;
 }
 
 .section-detail-info-card-contents .location-link {
@@ -779,6 +858,10 @@ table tbody tr:last-child > td {
 	text-decoration: none;
 }
 
+.dark-mode #section-detail-sidebar a {
+	color: #818181;
+}
+
 #section-detail-sidebar a.active {
 	color: var(--csm-green);
 }
@@ -795,14 +878,16 @@ table tbody tr:last-child > td {
 
 .modal.drop-confirmation h5 {
 	font-size: 25px;
-	color: #727070;
+	color: var(--csm-text);
 	margin: 30px auto 0.5rem;
+	transition: color 0.25s;
 }
 
 .modal.drop-confirmation p {
 	font-size: 14px;
-	color: #bfbfbf;
+	color: var(--csm-text);
 	margin-top: 0;
+	transition: color 0.25s;
 }
 
 #section-detail-body {
@@ -1000,9 +1085,10 @@ table tbody tr:last-child > td {
 }
 
 #spacetime-edit-form .mode-selection .mode-selection-options label {
-	color: black;
+	color: var(--csm-text);
 	font-weight: normal;
 	font-size: small;
+	transition: color 0.25s;
 }
 
 #spacetime-edit-form #date-of-change-fields input:not([type="radio"]) {

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -39,14 +39,16 @@ body {
 	--csm-neutral: #c0c0c0;
 	--csm-link-color: #0000ff;
 	--csm-card-background: #ffffff;
+	--csm-shadow-color: rgba(0, 0, 0, 0.15);
 }
 
 .theme-dark {
-	--csm-background: #1c1d1e;
+	--csm-background: #121314;
 	--csm-text: #ffffff;
 	--csm-text-bold: #ffffff;
 	--csm-link-color: #63c5ff;
 	--csm-card-background: #222222;
+	--csm-shadow-color: rgba(0, 0, 0, 0.3);
 }
 
 /* split out from variables for cleanliness */
@@ -255,7 +257,7 @@ header {
 	width: 320px;
 	min-width: 320px;
 	border-radius: 16px;
-	box-shadow: 0px 5px 50px rgba(0, 0, 0, 0.15);
+	box-shadow: 0px 5px 50px var(--csm-shadow-color);
 	min-height: 180px;
 	border-top: 30px solid;
 	border-top-color: red;
@@ -379,7 +381,7 @@ header {
 .section-card {
 	width: 320px;
 	overflow-x: hidden;
-	box-shadow: 0px 5px 50px rgba(0, 0, 0, 0.15);
+	box-shadow: 0px 5px 50px var(--csm-shadow-color);
 	border-radius: 20px;
 	background-color: var(--csm-card-background);
 	margin: 0 auto 50px;
@@ -391,7 +393,7 @@ header {
 }
 
 .theme-dark .section-card.full {
-	background-color: initial;
+	background-color: var(--csm-card-background);
 	opacity: 35%;
 }
 
@@ -925,7 +927,7 @@ table tbody tr:last-child > td {
 	font-size: 0.8em;
 	width: 10em;
 	text-align: center;
-	box-shadow: 0px 2px 10px 0px rgba(0, 0, 0, 0.15);
+	box-shadow: 0px 2px 10px 0px var(--csm-shadow-color);
 	background-color: white;
 	padding: 10px;
 	position: absolute;


### PR DESCRIPTION
Example pages:
![Screen Shot 2021-01-30 at 2 35 35 PM](https://user-images.githubusercontent.com/543055/106369732-cb803f80-6308-11eb-9569-9a92c2a81e38.png)
![Screen Shot 2021-01-30 at 2 35 41 PM](https://user-images.githubusercontent.com/543055/106369733-ccb16c80-6308-11eb-9bff-71ab5bd758ef.png)
![Screen Shot 2021-01-30 at 2 36 01 PM](https://user-images.githubusercontent.com/543055/106369734-ce7b3000-6308-11eb-928f-71769ee1e0c4.png)

The colors for regular mode were also tweaked a bit to use global CSS variables instead of local constants:
![Screen Shot 2021-01-30 at 2 35 17 PM](https://user-images.githubusercontent.com/543055/106369759-eb176800-6308-11eb-8bba-3f710c12d8cc.png)
![Screen Shot 2021-01-30 at 2 35 27 PM](https://user-images.githubusercontent.com/543055/106369760-ee125880-6308-11eb-9fea-f4a9939214fe.png)
![Screen Shot 2021-01-30 at 2 35 51 PM](https://user-images.githubusercontent.com/543055/106369763-ef438580-6308-11eb-8a44-c90cdbb131b7.png)
