### PR TITLE
Resource Caches

### DIFF
--- a/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { fetchJSON, fetchWithMethod, HTTP_METHODS } from "../../utils/api";
-import { getRoles } from "../../utils/user";
+import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
 import ResourceRow from "./ResourceRow";
 import { emptyResource, Resource, Worksheet } from "./ResourceTypes";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -9,7 +8,7 @@ import { faPlusCircle } from "@fortawesome/free-solid-svg-icons";
 /**
  * React component representing the entire resource table, managing all resource rows.
  */
-export const ResourceTable = ({ courseID }) => {
+export const ResourceTable = ({ courseID, roles, getResources, updateResources }) => {
   const [resources, setResources] = useState([]);
   const [canEdit, setCanEdit] = useState(false);
   const [addingResource, setAddingResource] = useState(false);
@@ -18,12 +17,11 @@ export const ResourceTable = ({ courseID }) => {
    * Gets resource data for a specific course when courseID changes
    */
   useEffect(() => {
-    fetchJSON(`/resources/${courseID}/resources`).then(data => {
+    setCanEdit(roles["COORDINATOR"].has(courseID));
+    getResources().then(data => {
       setResources(data);
-      getRoles().then(roles => setCanEdit(roles["COORDINATOR"].has(courseID)));
-      //setCanEdit(getRoles()["COORDINATOR"].has(courseID));
     });
-  }, [courseID]);
+  }, [courseID, roles]);
 
   /**
    * Merges fileFormData and newWorksheets with other resource attributes.
@@ -94,7 +92,7 @@ export const ResourceTable = ({ courseID }) => {
   ) {
     const resourceFormData = getResourceFormData(newResource, fileFormDataMap, newWorksheets);
     fetchWithMethod(`resources/${courseID}/resources/`, HTTP_METHODS.POST, resourceFormData, true).then(() => {
-      fetchJSON(`/resources/${courseID}/resources`).then(data => {
+      updateResources().then(data => {
         setResources(data);
       });
     });
@@ -111,7 +109,7 @@ export const ResourceTable = ({ courseID }) => {
   function handleUpdateResource(newResource, fileFormDataMap, newWorksheets) {
     const resourceFormData = getResourceFormData(newResource, fileFormDataMap, newWorksheets);
     fetchWithMethod(`resources/${courseID}/resources/`, HTTP_METHODS.PUT, resourceFormData, true).then(() => {
-      fetchJSON(`/resources/${courseID}/resources`).then(data => {
+      updateResources().then(data => {
         setResources(data);
       });
     });
@@ -122,7 +120,7 @@ export const ResourceTable = ({ courseID }) => {
    */
   function handleDeleteResource(resourceId) {
     fetchWithMethod(`resources/${courseID}/resources/`, HTTP_METHODS.DELETE, { id: resourceId }, false).then(() => {
-      fetchJSON(`/resources/${courseID}/resources`).then(data => {
+      updateResources().then(data => {
         setResources(data);
       });
     });

--- a/csm_web/frontend/src/utils/user.tsx
+++ b/csm_web/frontend/src/utils/user.tsx
@@ -1,21 +1,31 @@
 import { fetchJSON } from "./api";
-import { cloneDeep } from "lodash";
-
-const DEFAULT_ROLES = {
-  STUDENT: new Set(),
-  MENTOR: new Set(),
-  COORDINATOR: new Set()
-};
-
 interface Roles {
   STUDENT: Set<number>;
   MENTOR: Set<number>;
   COORDINATOR: Set<number>;
 }
 
+/**
+ * Creates an empty Roles object.
+ *
+ * @returns an empty Roles object
+ */
+export function emptyRoles(): Roles {
+  return {
+    STUDENT: new Set(),
+    MENTOR: new Set(),
+    COORDINATOR: new Set(),
+  }
+}
+
+/**
+ * Retrieves all user roles and groups them by role type for easier access.
+ *
+ * @returns all user roles split by role type
+ */
 export function getRoles(): Promise<Roles>{
   return fetchJSON("/profiles").then(profiles => {
-    const roles = cloneDeep(DEFAULT_ROLES);
+    const roles = emptyRoles();
     profiles.map(course => {
       roles[course.role].add(course.courseId);
     });


### PR DESCRIPTION
Added a cache for resource data to reduce the number of API calls made while switching tabs. The cache updates when new changes are submitted to the database, and data is retrieved from the cache if present.

Also refactored the roles function and how we retrieve role information to reduce the number of API calls, storing all role information on first page load instead of retrieving them every time the user switches tabs (as user privileges are unlikely to change in one session; refreshing the page to update privilege information is natural).