### PR TITLE
Add cron jobs with APScheduler

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: cd csm_web; gunicorn csm_web.wsgi
+clock: python csm_web/manage.py run_apscheduler

--- a/csm_web/csm_web/settings.py
+++ b/csm_web/csm_web/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "frontend",
     "django_extensions",
     "django.contrib.postgres",
+    "django_apscheduler",
 ]
 
 SHELL_PLUS_SUBCLASSES_IMPORT = [ModelSerializer, Serializer, DjangoModelFactory]

--- a/csm_web/scheduler/management/commands/run_apscheduler.py
+++ b/csm_web/scheduler/management/commands/run_apscheduler.py
@@ -1,0 +1,73 @@
+import logging
+
+from django.conf import settings
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from apscheduler.triggers.cron import CronTrigger
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django_apscheduler.jobstores import DjangoJobStore
+from django_apscheduler.models import DjangoJobExecution
+from django_apscheduler import util
+
+logger = logging.getLogger(__name__)
+
+
+@util.close_old_connections
+def create_attendances():
+    """
+    Wrapper function to pass into the job scheduler.
+    Runs the create_attendances command.
+    """
+    logger.info("Creating attendances...")
+    # TODO: uncomment when create_attendances is done
+    # call_command("create_attendances")
+
+
+@util.close_old_connections
+def delete_old_job_executions(max_age=604_800):
+    """
+    This job deletes APScheduler job execution entries older than `max_age` from the database.
+    It helps to prevent the database from filling up with old historical records that are no
+    longer useful.
+
+    :param max_age: The maximum length of time to retain historical job execution records.
+                    Defaults to 7 days.
+    """
+    DjangoJobExecution.objects.delete_old_job_executions(max_age)
+
+
+class Command(BaseCommand):
+    help = "Runs APScheduler."
+
+    def handle(self, *args, **options):
+        scheduler = BlockingScheduler(timezone=settings.TIME_ZONE)
+        scheduler.add_jobstore(DjangoJobStore(), "default")
+
+        scheduler.add_job(
+            create_attendances,
+            trigger=CronTrigger(second=0),  # TODO: change trigger time
+            id="create_attendances",
+            max_instances=1,
+            replace_existing=True,
+        )
+
+        logger.info("Added create_attendances job.")
+
+        scheduler.add_job(
+            delete_old_job_executions,
+            trigger=CronTrigger(day_of_week='mon', hour='00', minute='00'),
+            id="delete_old_job_executions",
+            max_instances=1,
+            replace_existing=True,
+        )
+
+        logger.info("Added delete_old_job_executions job.")
+
+        try:
+            logger.info("Starting scheduler...")
+            scheduler.start()
+        except KeyboardInterrupt:
+            logger.info("Stopping scheduler...")
+            scheduler.shutdown()
+            logger.info("Scheduler shut down successfully!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansimarkup==1.4.0
+APScheduler==3.7.0
 asgiref==3.4.1
 boto3==1.18.32
 botocore==1.21.32
@@ -12,6 +13,7 @@ cryptography==3.4.8
 defusedxml==0.7.1
 dj-database-url==0.5.0
 Django==3.2.6
+django-apscheduler==0.6.0
 django-csp==3.7
 django-extensions==3.1.3
 django-heroku==0.3.1


### PR DESCRIPTION
Created a new process to run a scheduler for cron jobs, replacing Advanced Scheduler from Heroku.

The scheduler runs `create_attendances` every week, and also cleans past execution logs every week.