### PR TITLE
Fix resource tab CSS for longer names

### DIFF
--- a/csm_web/frontend/static/frontend/css/resource_aggregation.css
+++ b/csm_web/frontend/static/frontend/css/resource_aggregation.css
@@ -18,7 +18,6 @@
 	font-size: 16px;
 	margin: 8px;
 	padding: 16px;
-	width: 88px;
 }
 
 .tab:hover {


### PR DESCRIPTION
Small one-line fix for longer names in resource tabs; they were overflowing for EECS16A and EECS16B.

However, the fix was to remove the fixed width of the tabs, which means that the wrapping for smaller screens (ex. mobile) is not as nice:
![image](https://user-images.githubusercontent.com/22699619/132138001-dd7f37e1-51d9-4529-ae4f-7382837a2170.png)
