### PR TITLE
Fix add new resource if no resources present

### DIFF
--- a/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
@@ -175,6 +175,10 @@ export const ResourceTable = ({ courseID, roles, getResources, updateResources }
    */
   function getNextResource() {
     const newResource = emptyResource();
+    // return empty resource if first resource to be added
+    if (resources.length == 0) {
+      return newResource;
+    }
     const lastResource = resources[resources.length - 1]; // get last resource
     newResource.weekNum = lastResource.weekNum + 1;
 


### PR DESCRIPTION
Hotfix to fix the edit modal for a new resource if it is the first resource to be created—it used to error because of an undefined "last" resource.