### PR TITLE
Modify frontend to give choice of virtual/in-person locations

### DIFF
--- a/csm_web/frontend/src/components/Course.js
+++ b/csm_web/frontend/src/components/Course.js
@@ -256,6 +256,13 @@ class SectionCard extends React.Component {
     if (!showModal && enrollmentSuccessful) {
       return <Redirect to="/" />;
     }
+    // set of all distinct locations
+    const spacetimeLocationSet = new Set();
+    for (const spacetime of spacetimes) {
+      spacetimeLocationSet.add(spacetime.location);
+    }
+    // remove the first location because it'll always be displayed
+    spacetimeLocationSet.delete(spacetimes[0].location);
     return (
       <React.Fragment>
         {showModal && <Modal closeModal={this.closeModal}>{this.modalContents().props.children}</Modal>}
@@ -264,10 +271,20 @@ class SectionCard extends React.Component {
             {description && <span className="section-card-description">{description}</span>}
             <p title="Location">
               <LocationIcon width={iconWidth} height={iconHeight} />{" "}
-              {/* TODO: For now this is hardcoded, but when sections return in person, this needs to be implemented.
-									An important note:  Backend returns location as null if it's a video-call link to avoid leaking info to unenrolled students,
-									so a strict (===) equality check is going to be very important here.  See scheduler/views.py for further explanation on 'leaking info'.*/}
-              Online
+              {spacetimes[0].location === null ? "Online" : spacetimes[0].location}
+              {spacetimeLocationSet.size > 0 && (
+                <span className="section-card-additional-times">
+                  {Array.from(spacetimeLocationSet).map((location, id) => (
+                    <React.Fragment key={id}>
+                      <span
+                        className="section-card-icon-placeholder"
+                        style={{ minWidth: iconWidth, minHeight: iconHeight }}
+                      />{" "}
+                      {location === null ? "Online" : location}
+                    </React.Fragment>
+                  ))}
+                </span>
+              )}
             </p>
             <p title="Time">
               <ClockIcon width={iconWidth} height={iconHeight} /> {spacetimes[0].time}

--- a/csm_web/frontend/src/components/MentorSection.js
+++ b/csm_web/frontend/src/components/MentorSection.js
@@ -335,7 +335,8 @@ class SpacetimeEditModal extends React.Component {
       time: timeString.slice(0, sliceIndex),
       isPermanent: false,
       changeDate: "",
-      mode: "virtual",
+      // Logic to determine whether or not the location is virtual or in person (same logic as backend to omit video call links)
+      mode: props.defaultSpacetime.location.startsWith("http") ? "virtual" : "inperson",
       showSaveSpinner: false
     };
     this.handleChange = this.handleChange.bind(this);
@@ -386,8 +387,7 @@ class SpacetimeEditModal extends React.Component {
       <Modal className="spacetime-edit-modal" closeModal={this.props.closeModal}>
         <form className="csm-form" id="spacetime-edit-form" onSubmit={this.handleSubmit}>
           <h4>Change Time and Location</h4>
-          {/* TODO: Uncomment this when Berkeley resumes in-person instruction (if I graduate online I'm gonna be real sad)
-						<div className="mode-selection">
+          <div className="mode-selection">
             <label>Section is</label>
             <div className="mode-selection-options">
               <label>
@@ -411,7 +411,7 @@ class SpacetimeEditModal extends React.Component {
                 Virtual
               </label>
             </div>
-					</div> */}
+          </div>
           <label>
             {mode === "inperson" ? "Location" : "Video Call Link"}
             <input


### PR DESCRIPTION
Removed previous TODO comments and implemented section cards for online/in-person sections, and enabled a choice of online/in-person locations.