### PR TITLE
Allow coords to also mentor a section

### DIFF
--- a/csm_web/frontend/src/components/Home.js
+++ b/csm_web/frontend/src/components/Home.js
@@ -24,9 +24,11 @@ export default class Home extends React.Component {
         </div>
         {profilesLoaded && (
           <div className="course-cards-container">
-            {Object.entries(groupBy(profiles, profile => profile.course)).map(([course, courseProfiles]) => (
-              <CourseCard key={course} profiles={courseProfiles} />
-            ))}
+            {Object.entries(groupBy(profiles, profile => [profile.course, profile.role])).map(
+              ([course, courseProfiles]) => (
+                <CourseCard key={course} profiles={courseProfiles} />
+              )
+            )}
           </div>
         )}
       </div>

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -170,10 +170,12 @@ class SectionSerializer(serializers.ModelSerializer):
         try:
             return obj.students.get(user=user)
         except Student.DoesNotExist:
+            coordinator = obj.course.coordinator_set.filter(user=user).first()
+            if coordinator:
+                return coordinator
             if obj.mentor and obj.mentor.user == user:
                 return obj.mentor
-            coordinator = obj.course.coordinator_set.filter(user=user).first()
-            return coordinator  # If coordinator is None we'd return None anyway at this point
+        return None  # no profile
 
     def get_user_role(self, obj):
         profile = self.user_associated_profile(obj)


### PR DESCRIPTION
Fixes #192.

Small frontend change to fix errors caused by coordinators also mentoring a section.

Also made a minor change to the backend `Section` serializer to give the coordinator full coord privileges to the section they're mentoring.