### PR TITLE
Add mentor meta card

### DIFF
--- a/csm_web/frontend/src/components/MentorSection.js
+++ b/csm_web/frontend/src/components/MentorSection.js
@@ -492,8 +492,9 @@ class SpacetimeEditModal extends React.Component {
   }
 }
 
-function MetaEditModal({ closeModal, sectionId, reloadSection }) {
-  const [formState, setFormState] = useState({ capacity: "", description: "" });
+function MetaEditModal({ closeModal, sectionId, reloadSection, capacity, description }) {
+  // use existing capacity and description as initial values
+  const [formState, setFormState] = useState({ capacity: capacity, description: description });
   function handleChange({ target: { name, value } }) {
     setFormState(prevFormState => ({ ...prevFormState, [name]: value }));
   }
@@ -536,7 +537,9 @@ function MetaEditModal({ closeModal, sectionId, reloadSection }) {
 MetaEditModal.propTypes = {
   sectionId: PropTypes.number.isRequired,
   closeModal: PropTypes.func.isRequired,
-  reloadSection: PropTypes.func.isRequired
+  reloadSection: PropTypes.func.isRequired,
+  capacity: PropTypes.number.isRequired,
+  description: PropTypes.string.isRequired
 };
 
 function MentorSectionInfo({
@@ -620,44 +623,54 @@ function MentorSectionInfo({
           )}
           {!loaded && <LoadingSpinner />}
         </InfoCard>
+        <div className="section-info-cards-right">
+          {spacetimes.map(({ override, ...spacetime }, index) => (
+            <SectionSpacetime
+              manySpacetimes={spacetimes.length > 1}
+              index={index}
+              key={spacetime.id}
+              spacetime={spacetime}
+              override={override}
+            >
+              {showModal === MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT && focusedSpacetimeID === spacetime.id && (
+                <SpacetimeEditModal
+                  key={spacetime.id}
+                  reloadSection={reloadSection}
+                  defaultSpacetime={spacetime}
+                  closeModal={closeModal}
+                />
+              )}
+              <button
+                className="info-card-edit-btn"
+                onClick={() => {
+                  setShowModal(MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT);
+                  setFocusedSpacetimeID(spacetime.id);
+                }}
+              >
+                <PencilIcon width="1em" height="1em" /> Edit
+              </button>
+            </SectionSpacetime>
+          ))}
 
-        {spacetimes.map(({ override, ...spacetime }, index) => (
-          <SectionSpacetime
-            manySpacetimes={spacetimes.length > 1}
-            index={index}
-            key={spacetime.id}
-            spacetime={spacetime}
-            override={override}
-          >
-            {showModal === MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT && focusedSpacetimeID === spacetime.id && (
-              <SpacetimeEditModal
-                key={spacetime.id}
-                reloadSection={reloadSection}
-                defaultSpacetime={spacetime}
-                closeModal={closeModal}
-              />
-            )}
-            <button
-              className="info-card-edit-btn"
-              onClick={() => {
-                setShowModal(MentorSectionInfo.MODAL_STATES.SPACETIME_EDIT);
-                setFocusedSpacetimeID(spacetime.id);
-              }}
-            >
-              <PencilIcon width="1em" height="1em" /> Edit
-            </button>
-          </SectionSpacetime>
-        ))}
-        {isCoordinator && (
           <InfoCard title="Meta">
-            <button
-              className="info-card-edit-btn"
-              onClick={() => setShowModal(MentorSectionInfo.MODAL_STATES.META_EDIT)}
-            >
-              <PencilIcon width="1em" height="1em" /> Edit
-            </button>
-            {showModal === MentorSectionInfo.MODAL_STATES.META_EDIT && (
-              <MetaEditModal sectionId={id} closeModal={closeModal} reloadSection={reloadSection} />
+            {isCoordinator && (
+              <React.Fragment>
+                <button
+                  className="info-card-edit-btn"
+                  onClick={() => setShowModal(MentorSectionInfo.MODAL_STATES.META_EDIT)}
+                >
+                  <PencilIcon width="1em" height="1em" /> Edit
+                </button>
+                {showModal === MentorSectionInfo.MODAL_STATES.META_EDIT && (
+                  <MetaEditModal
+                    sectionId={id}
+                    closeModal={closeModal}
+                    reloadSection={reloadSection}
+                    capacity={capacity}
+                    description={description}
+                  />
+                )}
+              </React.Fragment>
             )}
             <p>
               <span className="meta-field">Capacity:</span> {capacity}
@@ -666,7 +679,7 @@ function MentorSectionInfo({
               <span className="meta-field">Description:</span> {description}
             </p>
           </InfoCard>
-        )}
+        </div>
       </div>
     </React.Fragment>
   );

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -781,6 +781,12 @@ main {
 	flex-wrap: wrap;
 }
 
+.section-info-cards-right {
+	flex: 1;
+	display: flex;
+	flex-wrap: wrap;
+}
+
 .section-detail-info-card {
 	margin: 0 50px 50px 0;
 }
@@ -949,10 +955,16 @@ table tbody tr:last-child > td {
 
 #section-detail-body {
 	display: flex;
-	flex-wrap: wrap;
 	--csm-attendance-present: var(--csm-green);
 	--csm-attendance-excused: #797979;
 	--csm-attendance-unexcused: var(--csm-danger);
+}
+
+@media screen and (max-width: 1100px) {
+	/* only wrap for medium/small screens */
+	#section-detail-body {
+		flex-wrap: wrap;
+	}
 }
 
 #students-table .inline-plus-sign {


### PR DESCRIPTION
The meta card previously did not appear in the mentor view, meaning that mentors can't view descriptions or capacities. This is now changed, and the meta card can now be viewed by mentors, while editing privileges are still restricted to coordinators.

Some other small changes were made to the arrangement of the section info cards in the section view—the students list now takes its own space on the left, while the other cards flex-flow on the right. This means that it's a lot easier to see the rest of the cards, and we don't have any cards that end up hiding below the student list after wrapping.