### PR TITLE
Fix export attendances script with new database schema and output format

### DIFF
--- a/csm_web/scheduler/management/commands/export_attendances.py
+++ b/csm_web/scheduler/management/commands/export_attendances.py
@@ -1,53 +1,124 @@
 import csv
+import datetime
+from django.db.models import Q, Count, Prefetch
 from django.core.management import BaseCommand
-from scheduler.models import Course, Attendance
+from scheduler.models import Course, Attendance, Student
 
 
 class Command(BaseCommand):
     help = "Exports a CSV of all attendances for all students in the given course to stdout."
     COLS = (
+        "Course",
         "Student Name",
         "Student Email",
-        "Attendance Date",
-        "Attendance",
-        "Mentor Name",
-        "Mentor Email",
-        "Section Day(s)",
-        "Section Time(s)",
+        "Unexcused Absences",
     )
+
+    # OLD VERSION
+
+    # COLS = (
+    #     "Student Name",
+    #     "Student Email",
+    #     "Attendance Date",
+    #     "Attendance",
+    #     "Mentor Name",
+    #     "Mentor Email",
+    #     "Section Day(s)",
+    #     "Section Time(s)",
+    # )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.csvwriter = csv.writer(self.stdout, dialect='unix', quoting=csv.QUOTE_MINIMAL)
+        self.csvwriter = csv.writer(
+            self.stdout, dialect="unix", quoting=csv.QUOTE_MINIMAL
+        )
 
     def add_arguments(self, parser):
-        parser.add_argument("course", type=str, help="the name of the course")
+        parser.add_argument(
+            "course", type=str, help="the name of the course; use 'all' for all courses"
+        )
+        parser.add_argument(
+            "--all-students",
+            action="store_true",
+            help="whether to export for all students; otherwise, only for students with >= 2 unexcused absences",
+        )
 
     def handle(self, *args, **options):
-        course = Course.objects.get(name=options["course"].upper())
-        attendances = Attendance.objects.filter(student__active=True, student__section__course=course).select_related(
-            'student__user', 'student__section__mentor').prefetch_related(
-            'student__section__spacetimes').order_by("student__pk", "student__section__spacetimes__day_of_week",
-                                                     "student__section__spacetimes__start_time",
-                                                     "student__section__mentor")
-        # Write headers
+        course_name = options["course"]
+        all_students = options["all_students"]
+        if course_name == "all":
+            courses = Course.objects.all()
+        else:
+            courses = Course.objects.filter(name=course_name)
+
+        # header
         self._write(self.COLS)
-        for attendance in attendances:
-            student = attendance.student
-            section = student.section
-            mentor = section.mentor
-            spacetimes = list(section.spacetimes.all())
-            row = (
-                student.user.get_full_name(),
-                student.user.email,
-                str(attendance.date),
-                attendance.get_presence_display(),
-                mentor.user.get_full_name(),
-                mentor.user.email,
-                '|'.join(s.day_of_week for s in spacetimes),
-                '|'.join(str(s.start_time) for s in spacetimes),
+
+        for course in courses:
+            # add additional padding to be safe
+            start_date = course.section_start - datetime.timedelta(weeks=1)
+            end_date = course.valid_until + datetime.timedelta(weeks=1)
+            students = (
+                Student.objects.filter(active=True, section__course__name=course.name)
+            ).annotate(
+                unexcused_count=Count(
+                    "attendance",
+                    filter=(
+                        Q(attendance__presence="UN")
+                        & Q(
+                            attendance__sectionOccurrence__date__range=[
+                                start_date,
+                                end_date,
+                            ]
+                        )
+                    ),
+                )
             )
-            self._write(row)
+            if not all_students:
+                students = students.filter(unexcused_count__gte=2)
+            for student in students:
+                row = (
+                    course.name,
+                    student.name,
+                    student.user.email,
+                    student.unexcused_count,
+                )
+                self._write(row)
+
+        # OLD VERSION
+
+        # course = Course.objects.get(name=options["course"].upper())
+        # attendances = (
+        #     Attendance.objects.filter(
+        #         student__active=True, student__section__course=course
+        #     )
+        #     .select_related("student__user", "student__section__mentor")
+        #     .prefetch_related("student__section__spacetimes")
+        #     .order_by(
+        #         "student__pk",
+        #         "student__section__spacetimes__day_of_week",
+        #         "student__section__spacetimes__start_time",
+        #         "student__section__mentor",
+        #     )
+        # )
+        # # Write headers
+        # self._write(self.COLS)
+        # for attendance in attendances:
+        #     student = attendance.student
+        #     section = student.section
+        #     mentor = section.mentor
+        #     spacetimes = list(section.spacetimes.all())
+        #     row = (
+        #         student.user.get_full_name(),
+        #         student.user.email,
+        #         str(attendance.date),
+        #         attendance.get_presence_display(),
+        #         mentor.user.get_full_name(),
+        #         mentor.user.email,
+        #         "|".join(s.day_of_week for s in spacetimes),
+        #         "|".join(str(s.start_time) for s in spacetimes),
+        #     )
+        #     self._write(row)
 
     def _write(self, row):
         self.csvwriter.writerow(row)


### PR DESCRIPTION
Rewrite old export attendances script to work with the new database schema, and change the output format to be more concise.

The old script is still left in comments for reference, in case we ever want to incorporate more options.