### PR TITLE
Restyle section view to have section cards in a grid

### DIFF
--- a/csm_web/frontend/src/components/Course.tsx
+++ b/csm_web/frontend/src/components/Course.tsx
@@ -131,16 +131,6 @@ export default class Course extends React.Component<CourseProps, CourseState> {
 
     return !(name && sectionsLoaded) ? null : (
       <div id="course-section-selector">
-        <div id="course-left-col">
-          {userIsCoordinator && (
-            <button
-              className="csm-btn export-data-btn"
-              onClick={() => this.setState({ showModal: true, whichModal: COURSE_MODAL_TYPE.exportData })}
-            >
-              Export Data
-            </button>
-          )}
-        </div>
         <div id="course-section-controls">
           <h2 className="course-title">{name}</h2>
           <div id="day-selector">
@@ -169,12 +159,20 @@ export default class Course extends React.Component<CourseProps, CourseState> {
             Show unavailable
           </label>
           {userIsCoordinator && (
-            <button
-              className="csm-btn create-section-btn"
-              onClick={() => this.setState({ showModal: true, whichModal: COURSE_MODAL_TYPE.createSection })}
-            >
-              <span className="inline-plus-sign">+ </span>Create Section
-            </button>
+            <div id="course-coord-buttons">
+              <button
+                className="csm-btn create-section-btn"
+                onClick={() => this.setState({ showModal: true, whichModal: COURSE_MODAL_TYPE.createSection })}
+              >
+                <span className="inline-plus-sign">+ </span>Create Section
+              </button>
+              <button
+                className="csm-btn export-data-btn"
+                onClick={() => this.setState({ showModal: true, whichModal: COURSE_MODAL_TYPE.exportData })}
+              >
+                Export Data
+              </button>
+            </div>
           )}
         </div>
         <div id="course-section-list">

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -404,6 +404,8 @@ header {
 	box-shadow: 0px 5px 50px rgba(0, 0, 0, 0.15);
 	border-radius: 20px;
 	margin: 0 auto 50px;
+	display: flex;
+	flex-direction: column;
 }
 
 .section-card.full {
@@ -413,6 +415,7 @@ header {
 .section-card-contents {
 	position: relative;
 	padding: 10px 20px 0;
+	flex: 1;
 }
 
 .section-card-contents p {
@@ -472,19 +475,13 @@ header {
 	justify-content: center;
 }
 
-#course-left-col {
-	top: 0;
-	align-self: flex-start;
-	margin-top: 5%;
-}
-
 .export-data-btn {
 	font-size: 18px;
 	border: none;
 	cursor: pointer;
-	margin: 0 auto !important;
 	display: block;
 	padding: 8px;
+	margin-left: 5px;
 }
 
 .data-export-modal {
@@ -542,6 +539,12 @@ header {
 	margin: 0 0 10px;
 }
 
+#course-coord-buttons {
+	display: flex;
+	width: max-content;
+	margin: 0 auto;
+}
+
 .course-title {
 	color: #6d6d6d;
 	font-size: 2.5em;
@@ -583,19 +586,16 @@ header {
 }
 
 #course-section-list {
-	height: 50vh;
+	width: 75vw;
+	margin: 0 auto;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+	grid-gap: 10px;
 }
 
 #course-section-list-empty {
-	width: 300px; /* Match width of section card so day selector stays stationary */
 	color: #646464;
 	text-align: center;
-}
-
-#course-section-selector {
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: center;
 }
 
 #course-section-selector .modal h3 {


### PR DESCRIPTION
Modified the section view for both coordinators and students (they share the same component) to have sections in a grid below the day selection:

![image](https://user-images.githubusercontent.com/22699619/151682655-36f03c34-60cd-4816-8c4e-55558ccb8314.png)
![image](https://user-images.githubusercontent.com/22699619/151682663-83ce9b8a-f9a2-44d3-a13d-ce3e8006733c.png)
![image](https://user-images.githubusercontent.com/22699619/151682668-d2971702-bdbf-422b-9474-2e3967533e5f.png)
