### PR TITLE
Modify how the setup script sources .env

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -65,7 +65,7 @@ sleep 1
 pwd > "$VIRTUAL_ENV/.project_dir"
 
 # Add env variables to virutalenv activate script so that not everything needs to be run with 'heroku local'
-sed 's/^/export /' .env >> "$VIRTUAL_ENV/bin/activate"
+echo 'set -a; source $(cat $VIRTUAL_ENV/.project_dir)/.env; set +a' >> "$VIRTUAL_ENV/bin/activate"
 
 # Setup postgres DB if needed
 if ! psql -lt | grep -q '^ *csm_web_dev *'


### PR DESCRIPTION
Currently, the `setup.sh` script adds the contents of `.env` to the virtual environment `activate` script, so that the environment variables are set whenever the user starts the virtual environment.

However, if the user decides to modify the `.env` file in any way, none of these changes are reflected in the `activate` script, and as such none of the new changes will be reflected in the environment variables.

A better way to do this would be to not duplicate the environment variables, and instead just source the `.env` file directly. To alleviate the need to prepend `export` to every line, we can also use `set -a` to make every `KEY=VALUE` pair be exported. This option is then reverted after we source the `.env` file with `set +a`.