### PR TITLE
Migrate to react-query

### DIFF
--- a/csm_web/frontend/src/components/App.tsx
+++ b/csm_web/frontend/src/components/App.tsx
@@ -33,7 +33,8 @@ const App = () => {
           <Route path="courses/*" element={<CourseMenu />} />
           <Route path="resources/*" element={<Resources />} />
           <Route path="matcher/*" element={<EnrollmentMatcher />} />
-        <Route path="policies/*" element={<Policies />} />
+          <Route path="policies/*" element={<Policies />} />
+          <Route path="*" element={<NotFound />} />
         </Route>
       </Routes>
     </ErrorBoundary>
@@ -135,6 +136,13 @@ function Header(): React.ReactElement {
     </header>
   );
 }
+
+/**
+ * 404 not found page.
+ */
+const NotFound = () => {
+  return <h3>Page not found</h3>;
+};
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;

--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Link, Route, Routes } from "react-router-dom";
-import { useCourses, useUserInfo } from "../utils/queries/base";
+import { useCourses } from "../utils/queries/course";
+import { useUserInfo } from "../utils/queries/base";
 import { Course as CourseType, UserInfo } from "../utils/types";
 import Course from "./course/Course";
 import LoadingSpinner from "./LoadingSpinner";

--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react";
 import { Link, Route, Routes } from "react-router-dom";
-import { useCourses } from "../utils/queries/course";
+import { useCourses } from "../utils/queries/courses";
 import { useUserInfo } from "../utils/queries/base";
 import { Course as CourseType, UserInfo } from "../utils/types";
 import Course from "./course/Course";

--- a/csm_web/frontend/src/components/Home.tsx
+++ b/csm_web/frontend/src/components/Home.tsx
@@ -1,19 +1,16 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { groupBy } from "lodash";
-import { useProfiles } from "../utils/query";
+import { useProfiles } from "../utils/queries/base";
 import { ROLES } from "./section/Section";
 import { Profile } from "../utils/types";
 import LoadingSpinner from "./LoadingSpinner";
 
 const Home = () => {
-  const { data: profiles, isLoading: profilesLoading } = useProfiles();
+  const { data: profiles, isSuccess: profilesLoaded } = useProfiles();
 
   let content = null;
-  if (profilesLoading) {
-    // fetching profiles
-    content = <LoadingSpinner />;
-  } else {
+  if (profilesLoaded) {
     // loaded, no error
     content = (
       <div className="course-cards-container">
@@ -24,6 +21,9 @@ const Home = () => {
         )}
       </div>
     );
+  } else {
+    // fetching profiles
+    content = <LoadingSpinner />;
   }
 
   return (

--- a/csm_web/frontend/src/components/Home.tsx
+++ b/csm_web/frontend/src/components/Home.tsx
@@ -7,7 +7,7 @@ import { Profile } from "../utils/types";
 import LoadingSpinner from "./LoadingSpinner";
 
 const Home = () => {
-  const { data: profiles, isSuccess: profilesLoaded } = useProfiles();
+  const { data: profiles, isSuccess: profilesLoaded, isError: profilesLoadError } = useProfiles();
 
   let content = null;
   if (profilesLoaded) {
@@ -15,12 +15,23 @@ const Home = () => {
     content = (
       <div className="course-cards-container">
         {Object.entries(groupBy(profiles, (profile: Profile) => [profile.course, profile.role])).map(
-          ([course, courseProfiles]) => (
-            <CourseCard key={course} profiles={courseProfiles} />
-          )
+          ([course, courseProfiles]) => {
+            if (courseProfiles[0].role === ROLES.MENTOR) {
+              const courseProfilesWithSection = courseProfiles.filter((profile: Profile) => profile.sectionId);
+              if (courseProfilesWithSection.length > 0) {
+                return <CourseCard key={course} profiles={courseProfilesWithSection} />;
+              }
+              // otherwise, mentor with no section; do not show the course card
+            } else {
+              return <CourseCard key={course} profiles={courseProfiles} />;
+            }
+          }
         )}
       </div>
     );
+  } else if (profilesLoadError) {
+    // error during load
+    content = <h3>Profiles not found</h3>;
   } else {
     // fetching profiles
     content = <LoadingSpinner />;

--- a/csm_web/frontend/src/components/course/Course.tsx
+++ b/csm_web/frontend/src/components/course/Course.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
-import { useCourseSections } from "../../utils/queries/course";
+import { useCourseSections } from "../../utils/queries/courses";
 import { Course as CourseType } from "../../utils/types";
 import { CreateSectionModal } from "./CreateSectionModal";
 import { DataExportModal } from "./DataExportModal";
@@ -42,7 +42,10 @@ const Course = ({ courses, priorityEnrollment, enrollmentTimes }: CourseProps): 
    * Sections grouped by day of the week, and whether the user is a corodinator.
    */
   const { data: jsonSections, isSuccess: sectionsLoaded, refetch: reloadSections } = useCourseSections(
-    courseId ? parseInt(courseId) : undefined
+    courseId ? parseInt(courseId) : undefined,
+    response => {
+      setCurrDayGroup(Object.keys(response.sections)[0]);
+    }
   );
 
   /**

--- a/csm_web/frontend/src/components/course/CreateSectionModal.tsx
+++ b/csm_web/frontend/src/components/course/CreateSectionModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useUserEmails } from "../../utils/queries/base";
-import { useSectionCreateMutation } from "../../utils/queries/section";
+import { useSectionCreateMutation } from "../../utils/queries/sections";
 import { Spacetime } from "../../utils/types";
 import Modal from "../Modal";
 import { DAYS_OF_WEEK } from "../section/utils";

--- a/csm_web/frontend/src/components/course/DataExportModal.tsx
+++ b/csm_web/frontend/src/components/course/DataExportModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { normalizeEndpoint } from "../../utils/api";
-import { useCourses } from "../../utils/queries/base";
+import { useCourses } from "../../utils/queries/course";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 

--- a/csm_web/frontend/src/components/course/DataExportModal.tsx
+++ b/csm_web/frontend/src/components/course/DataExportModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { normalizeEndpoint } from "../../utils/api";
-import { useCourses } from "../../utils/query";
+import { useCourses } from "../../utils/queries/base";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 
@@ -12,7 +12,7 @@ interface DataExportModalProps {
  * Modal that coords use to export a csv of student emails in selected courses.
  */
 export const DataExportModal = ({ closeModal }: DataExportModalProps): React.ReactElement => {
-  const { data: courses, isLoading: coursesLoading } = useCourses();
+  const { data: courses, isSuccess: coursesLoaded } = useCourses();
 
   const [courseChecks, setCourseChecks] = useState<Map<number, boolean>>(new Map());
 
@@ -20,7 +20,7 @@ export const DataExportModal = ({ closeModal }: DataExportModalProps): React.Rea
    * Map of course id to course name.
    */
   const courseMap = useMemo(() => {
-    if (courses && !coursesLoading) {
+    if (coursesLoaded) {
       const coursesById = new Map<number, string>();
       for (const course of courses) {
         coursesById.set(course.id, course.name);
@@ -35,7 +35,7 @@ export const DataExportModal = ({ closeModal }: DataExportModalProps): React.Rea
    * Initialize map of course id to boolean (whether the course is checked)
    */
   useEffect(() => {
-    if (courses && !coursesLoading) {
+    if (coursesLoaded) {
       const courseCheckbyId = new Map<number, boolean>();
       for (const course of courses) {
         courseCheckbyId.set(course.id, false);
@@ -98,7 +98,7 @@ export const DataExportModal = ({ closeModal }: DataExportModalProps): React.Rea
       <div className="data-export-modal">
         <div className="data-export-modal-header">Download csv of student emails in selected courses</div>
         <div className="data-export-modal-selection">
-          {coursesLoading ? <LoadingSpinner id="course-menu-loading-spinner" /> : renderCheckGrid()}
+          {coursesLoaded ? renderCheckGrid() : <LoadingSpinner id="course-menu-loading-spinner" />}
         </div>
         <div className="data-export-modal-download">
           <button className="csm-btn export-data-btn" onClick={getStudentEmails}>

--- a/csm_web/frontend/src/components/course/DataExportModal.tsx
+++ b/csm_web/frontend/src/components/course/DataExportModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { normalizeEndpoint } from "../../utils/api";
-import { useCourses } from "../../utils/queries/course";
+import { useCourses } from "../../utils/queries/courses";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 

--- a/csm_web/frontend/src/components/course/DataExportModal.tsx
+++ b/csm_web/frontend/src/components/course/DataExportModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { normalizeEndpoint } from "../../utils/api";
 import { useCourses } from "../../utils/query";
 import LoadingSpinner from "../LoadingSpinner";
@@ -12,29 +12,34 @@ interface DataExportModalProps {
  * Modal that coords use to export a csv of student emails in selected courses.
  */
 export const DataExportModal = ({ closeModal }: DataExportModalProps): React.ReactElement => {
+  const { data: courses, isLoading: coursesLoading } = useCourses();
+
+  const [courseChecks, setCourseChecks] = useState<Map<number, boolean>>(new Map());
+
   /**
    * Map of course id to course name.
    */
-  const [courseMap, setCourseMap] = useState<Map<number, string>>(new Map());
-  /**
-   * Map of course id to boolean (whether the course is checked)
-   */
-  const [courseChecks, setCourseChecks] = useState<Map<number, boolean>>(new Map());
-
-  const { data: courses, isLoading: coursesLoading } = useCourses();
-
-  /**
-   * Construct a map of course id to course name.
-   */
-  useMemo(() => {
+  const courseMap = useMemo(() => {
     if (courses && !coursesLoading) {
       const coursesById = new Map<number, string>();
-      const courseCheckbyId = new Map<number, boolean>();
       for (const course of courses) {
         coursesById.set(course.id, course.name);
+      }
+      return coursesById;
+    }
+    // not done loading yet
+    return undefined as never;
+  }, [courses]);
+
+  /**
+   * Initialize map of course id to boolean (whether the course is checked)
+   */
+  useEffect(() => {
+    if (courses && !coursesLoading) {
+      const courseCheckbyId = new Map<number, boolean>();
+      for (const course of courses) {
         courseCheckbyId.set(course.id, false);
       }
-      setCourseMap(coursesById);
       setCourseChecks(courseCheckbyId);
     }
   }, [courses]);

--- a/csm_web/frontend/src/components/course/SectionCard.tsx
+++ b/csm_web/frontend/src/components/course/SectionCard.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Link, Navigate } from "react-router-dom";
 
-import { EnrollStudentMutationResponse, useEnrollStudentMutation } from "../../utils/queries/section";
+import { EnrollUserMutationResponse, useEnrollUserMutation } from "../../utils/queries/sections";
 import { Mentor, Spacetime } from "../../utils/types";
 import Modal, { ModalCloser } from "../Modal";
 
@@ -36,7 +36,7 @@ export const SectionCard = ({
   /**
    * Mutation to enroll a student in the section.
    */
-  const enrollStudentMutation = useEnrollStudentMutation(id);
+  const enrollStudentMutation = useEnrollUserMutation(id);
 
   /**
    * Whether to show the modal (after an attempt to enroll).
@@ -67,7 +67,7 @@ export const SectionCard = ({
         setEnrollmentSuccessful(true);
         setShowModal(true);
       },
-      onError: ({ detail }: EnrollStudentMutationResponse) => {
+      onError: ({ detail }: EnrollUserMutationResponse) => {
         setEnrollmentSuccessful(false);
         setErrorMessage(detail);
         setShowModal(true);

--- a/csm_web/frontend/src/components/enrollment_automation/EnrollmentMatcher.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/EnrollmentMatcher.tsx
@@ -122,7 +122,8 @@ export function EnrollmentMatcher(): JSX.Element {
                 />
               }
             />
-            <Route index element={defaultMatcher} />
+            {/* for any other path, resort to default */}
+            <Route path="*" element={defaultMatcher} />
           </Routes>
         </div>
       </div>

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/EditStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/EditStage.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { fetchJSON, fetchWithMethod } from "../../../utils/api";
+import {
+  useMatcherAssignmentMutation,
+  useMatcherCreateSectionsMutation,
+  useMatcherMentors
+} from "../../../utils/queries/matcher";
 import { Mentor, Profile } from "../../../utils/types";
 import Modal from "../../Modal";
 import { SearchBar } from "../../SearchBar";
+import { Tooltip } from "../../Tooltip";
 import { Calendar } from "../calendar/Calendar";
 import { CalendarEventSingleTime, DAYS, DAYS_ABBREV } from "../calendar/CalendarTypes";
 import { Assignment, Slot, SlotPreference, Time } from "../EnrollmentAutomationTypes";
 import { formatInterval, formatTime } from "../utils";
-
-import { Tooltip } from "../../Tooltip";
 
 import ErrorIcon from "../../../../static/frontend/img/error_outline.svg";
 import InfoIcon from "../../../../static/frontend/img/info.svg";
@@ -69,7 +72,6 @@ interface EditStageProps {
   slots: Slot[];
   assignments: Assignment[];
   prefByMentor: Map<number, SlotPreference[]>;
-  refreshAssignments: () => void;
   prevStage: () => void;
 }
 
@@ -78,8 +80,7 @@ export const EditStage = ({
   slots,
   assignments,
   prefByMentor,
-  prevStage,
-  refreshAssignments
+  prevStage
 }: EditStageProps): React.ReactElement => {
   /**
    * Table of mentor information and section metadata for editing.
@@ -153,21 +154,27 @@ export const EditStage = ({
 
   const [errorMessage, setErrorMessage] = useState<string>("");
 
+  const { data: jsonMentors, isSuccess: jsonMentorsLoaded } = useMatcherMentors(profile.courseId);
+  const matcherAssignmentMutation = useMatcherAssignmentMutation(profile.courseId);
+  const matcherCreateSectionsMutation = useMatcherCreateSectionsMutation(profile.courseId);
+
   /**
    * History for redirection after section creation.
    */
   const navigate = useNavigate();
 
-  /* Fetch mentor data */
+  /**
+   * Process mentor json data.
+   */
   useEffect(() => {
-    fetchJSON(`/matcher/${profile.courseId}/mentors`).then((data: any) => {
-      const newMentorsById = new Map<number, Mentor>();
-      data.mentors.forEach((mentor: Mentor) => {
-        newMentorsById.set(mentor.id, mentor);
-      });
-      setMentorsById(newMentorsById);
+    if (!jsonMentorsLoaded) return;
+
+    const newMentorsById = new Map<number, Mentor>();
+    jsonMentors.mentors.forEach((mentor: Mentor) => {
+      newMentorsById.set(mentor.id, mentor);
     });
-  }, []);
+    setMentorsById(newMentorsById);
+  }, [jsonMentors]);
 
   /* Sort slots by earliest day and then by earliest start time */
   useEffect(() => {
@@ -422,12 +429,7 @@ export const EditStage = ({
    */
   const saveAssignment = () => {
     const newAssignments = gatherAssignments();
-
-    fetchWithMethod(`/matcher/${profile.courseId}/assignment`, "PUT", {
-      assignment: newAssignments
-    }).then(() => {
-      refreshAssignments();
-    });
+    matcherAssignmentMutation.mutate({ assignment: newAssignments });
   };
 
   /**
@@ -436,18 +438,19 @@ export const EditStage = ({
   const createSections = () => {
     const newAssignments = gatherAssignments();
 
-    fetchWithMethod(`/matcher/${profile.courseId}/create`, "POST", {
-      assignment: newAssignments
-    }).then(async response => {
-      if (response.ok) {
-        navigate("/");
-      } else {
-        const json = await response.json();
-        console.error(json);
-        setErrorMessage(json.error ?? "Error creating sections");
-        setCreateConfirmModalOpen(false);
+    matcherCreateSectionsMutation.mutate(
+      { assignment: newAssignments },
+      {
+        onSuccess: () => {
+          navigate("/");
+        },
+        onError: response => {
+          console.error(response);
+          setErrorMessage(response.error ?? "Error creating sections");
+          setCreateConfirmModalOpen(false);
+        }
       }
-    });
+    );
   };
 
   const handleSearchChange = (term?: string) => {

--- a/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { fetchJSON } from "../../utils/api";
-import { useCourses, useProfiles } from "../../utils/query";
+import { useCourses, useProfiles } from "../../utils/queries/base";
 import { getRoles, Roles } from "../../utils/user";
 import LoadingSpinner from "../LoadingSpinner";
 import ResourceTable from "./ResourceTable";
@@ -10,27 +10,22 @@ export const Resources = (): React.ReactElement => {
   const [selectedCourseID, setSelectedCourseID] = useState<number>(1);
   const [cache, setCache] = useState<Map<number, any>>(new Map());
 
-  const { data: profiles, isLoading: profilesLoading } = useProfiles();
-  const { data: courses, isLoading: coursesLoading } = useCourses();
+  const { data: profiles, isSuccess: profilesLoaded } = useProfiles();
+  const { data: courses, isSuccess: coursesLoaded } = useCourses();
 
   /**
    * Organize profiles into roles upon load.
    */
   const roles = useMemo<Roles>(() => {
-    if (profiles && !profilesLoading) {
+    if (profilesLoaded) {
       return getRoles(profiles);
     }
     // not done loading yet
     return undefined as never;
   }, [profiles]);
 
-  /**
-   * Whether any query is currently loading.
-   */
-  const loading = profilesLoading || coursesLoading || roles === null;
-
-  // loading spinner
-  if (loading) {
+  // display loading spinner if anything is loading
+  if (!profilesLoaded || !coursesLoaded || roles === undefined) {
     return (
       <div className="spinner-div">
         <LoadingSpinner />
@@ -79,7 +74,7 @@ export const Resources = (): React.ReactElement => {
     <div className="outer">
       <div className="tabs">
         <div className="tab-list">
-          {courses!.map(course => (
+          {courses.map(course => (
             <button
               onClick={() => handleTabClick(course.id)}
               key={course.id}

--- a/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
@@ -1,15 +1,12 @@
 import React, { useMemo, useState } from "react";
-import { fetchJSON } from "../../utils/api";
 import { useProfiles } from "../../utils/queries/base";
-import { useCourses } from "../../utils/queries/course";
+import { useCourses } from "../../utils/queries/courses";
 import { getRoles, Roles } from "../../utils/user";
 import LoadingSpinner from "../LoadingSpinner";
 import ResourceTable from "./ResourceTable";
-import { Resource } from "./ResourceTypes";
 
 export const Resources = (): React.ReactElement => {
   const [selectedCourseID, setSelectedCourseID] = useState<number>(1);
-  const [cache, setCache] = useState<Map<number, any>>(new Map());
 
   const { data: profiles, isSuccess: profilesLoaded } = useProfiles();
   const { data: courses, isSuccess: coursesLoaded } = useCourses();
@@ -38,39 +35,6 @@ export const Resources = (): React.ReactElement => {
     setSelectedCourseID(courseID);
   }
 
-  /**
-   * Retrieves resources from cache, populating the cache if cache miss.
-   *
-   * @param courseID id of course to get resources for
-   * @returns promise for asynchronous data fetch
-   */
-  function getResources(courseID: number): Promise<Array<Resource>> {
-    if (cache.has(courseID)) {
-      // still create promise for cache retrieve
-      return new Promise(resolve => {
-        resolve(cache.get(courseID));
-      });
-    } else {
-      // get data and store in cache
-      return updateResources(courseID);
-    }
-  }
-
-  /**
-   * Fetches resources from API, replacing the cache entry if it already exists.
-   *
-   * @param courseID id of course to update resources for
-   * @returns promise for asynchronous data fetch
-   */
-  function updateResources(courseID: number): Promise<Array<Resource>> {
-    return fetchJSON(`/resources/${courseID}/resources`).then(data => {
-      const updatedCache = new Map(cache);
-      updatedCache.set(courseID, data);
-      setCache(updatedCache);
-      return data;
-    });
-  }
-
   return (
     <div className="outer">
       <div className="tabs">
@@ -86,12 +50,7 @@ export const Resources = (): React.ReactElement => {
           ))}
         </div>
       </div>
-      <ResourceTable
-        courseID={selectedCourseID}
-        roles={roles}
-        getResources={() => getResources(selectedCourseID)}
-        updateResources={() => updateResources(selectedCourseID)}
-      />
+      <ResourceTable courseID={selectedCourseID} roles={roles} />
     </div>
   );
 };

--- a/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/Resources.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { fetchJSON } from "../../utils/api";
-import { useCourses, useProfiles } from "../../utils/queries/base";
+import { useProfiles } from "../../utils/queries/base";
+import { useCourses } from "../../utils/queries/course";
 import { getRoles, Roles } from "../../utils/user";
 import LoadingSpinner from "../LoadingSpinner";
 import ResourceTable from "./ResourceTable";

--- a/csm_web/frontend/src/components/section/CoordinatorAddStudentModal.tsx
+++ b/csm_web/frontend/src/components/section/CoordinatorAddStudentModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
+import { useUserEmails } from "../../utils/queries/base";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 
@@ -16,7 +17,6 @@ enum CoordModalStates {
 
 interface CoordinatorAddStudentModalProps {
   closeModal: (arg0?: boolean) => void;
-  userEmails: string[];
   sectionId: number;
 }
 
@@ -46,9 +46,9 @@ interface ActionType {
 
 export function CoordinatorAddStudentModal({
   closeModal,
-  userEmails,
   sectionId
 }: CoordinatorAddStudentModalProps): React.ReactElement {
+  const { data: userEmails, isSuccess: userEmailsLoaded } = useUserEmails();
   const [emailsToAdd, setEmailsToAdd] = useState<string[]>([""]);
   const [response, setResponse] = useState<ResponseType>({} as ResponseType);
   /**
@@ -200,9 +200,7 @@ export function CoordinatorAddStudentModal({
             </div>
           ))}
           <datalist id="user-emails-list">
-            {userEmails.map(email => (
-              <option key={email} value={email} />
-            ))}
+            {userEmailsLoaded && userEmails.map(email => <option key={email} value={email} />)}
           </datalist>
         </div>
       </div>

--- a/csm_web/frontend/src/components/section/MentorSection.tsx
+++ b/csm_web/frontend/src/components/section/MentorSection.tsx
@@ -6,7 +6,7 @@ import { groupBy } from "lodash";
 import MentorSectionAttendance from "./MentorSectionAttendance";
 import MentorSectionRoster from "./MentorSectionRoster";
 import MentorSectionInfo from "./MentorSectionInfo";
-import { useSectionAttendances, useSectionStudents } from "../../utils/query";
+import { useSectionAttendances, useSectionStudents } from "../../utils/queries/section";
 
 interface MentorSectionProps {
   id: number;
@@ -35,12 +35,11 @@ export default function MentorSection({
   userRole,
   mentor
 }: MentorSectionProps) {
-  const { data: students, isLoading: studentsLoading } = useSectionStudents(id);
-  const { data: jsonAttendances, isLoading: attendancesLoading } = useSectionAttendances(id);
+  const { data: jsonAttendances, isSuccess: jsonAttendancesLoaded } = useSectionAttendances(id);
   const [attendances, setAttendances] = useState<GroupedAttendances>(undefined as never);
 
   useEffect(() => {
-    if (jsonAttendances && !attendancesLoading) {
+    if (jsonAttendancesLoaded) {
       const groupedAttendances = groupBy(
         jsonAttendances.flatMap(({ attendances }: RawAttendance) =>
           attendances
@@ -71,7 +70,7 @@ export default function MentorSection({
     setAttendances(updatedAttendances);
   };
 
-  const loaded = !studentsLoading && !attendancesLoading && !!attendances;
+  const attendancesLoaded = jsonAttendancesLoaded && !!attendances;
 
   return (
     <SectionDetail
@@ -88,7 +87,11 @@ export default function MentorSection({
         <Route
           path="attendance"
           element={
-            <MentorSectionAttendance attendances={attendances} loaded={loaded} updateAttendance={updateAttendance} />
+            <MentorSectionAttendance
+              attendances={attendances}
+              loaded={attendancesLoaded}
+              updateAttendance={updateAttendance}
+            />
           }
         />
         <Route path="roster" element={<MentorSectionRoster id={id} />} />
@@ -99,8 +102,6 @@ export default function MentorSection({
               isCoordinator={userRole === ROLES.COORDINATOR}
               mentor={mentor}
               reloadSection={reloadSection}
-              students={students!}
-              loaded={loaded}
               spacetimes={spacetimes}
               capacity={capacity}
               description={description}

--- a/csm_web/frontend/src/components/section/MentorSection.tsx
+++ b/csm_web/frontend/src/components/section/MentorSection.tsx
@@ -6,7 +6,7 @@ import { groupBy } from "lodash";
 import MentorSectionAttendance from "./MentorSectionAttendance";
 import MentorSectionRoster from "./MentorSectionRoster";
 import MentorSectionInfo from "./MentorSectionInfo";
-import { useSectionAttendances, useSectionStudents } from "../../utils/queries/sections";
+import { useSectionAttendances } from "../../utils/queries/sections";
 
 interface MentorSectionProps {
   id: number;

--- a/csm_web/frontend/src/components/section/MentorSection.tsx
+++ b/csm_web/frontend/src/components/section/MentorSection.tsx
@@ -89,6 +89,7 @@ export default function MentorSection({
           element={
             <MentorSectionAttendance
               attendances={attendances}
+              sectionId={id}
               loaded={attendancesLoaded}
               updateAttendance={updateAttendance}
             />

--- a/csm_web/frontend/src/components/section/MentorSection.tsx
+++ b/csm_web/frontend/src/components/section/MentorSection.tsx
@@ -6,7 +6,7 @@ import { groupBy } from "lodash";
 import MentorSectionAttendance from "./MentorSectionAttendance";
 import MentorSectionRoster from "./MentorSectionRoster";
 import MentorSectionInfo from "./MentorSectionInfo";
-import { useSectionAttendances, useSectionStudents } from "../../utils/queries/section";
+import { useSectionAttendances, useSectionStudents } from "../../utils/queries/sections";
 
 interface MentorSectionProps {
   id: number;

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -10,7 +10,7 @@ import StudentDropper from "./StudentDropper";
 import XIcon from "../../../static/frontend/img/x.svg";
 import PencilIcon from "../../../static/frontend/img/pencil.svg";
 import MetaEditModal from "./MetaEditModal";
-import { useSectionStudents } from "../../utils/query";
+import { useSectionStudents } from "../../utils/queries/section";
 import SpacetimeDeleteModal from "./SpacetimeDeleteModal";
 
 enum ModalStates {
@@ -21,8 +21,6 @@ enum ModalStates {
 }
 
 interface MentorSectionInfoProps {
-  students: Student[];
-  loaded: boolean;
   spacetimes: Spacetime[];
   reloadSection: () => void;
   isCoordinator: boolean;
@@ -41,7 +39,7 @@ export default function MentorSectionInfo({
   id: sectionId,
   description
 }: MentorSectionInfoProps) {
-  const { data: students, isLoading: studentsLoading } = useSectionStudents(sectionId);
+  const { data: students, isSuccess: studentsLoaded } = useSectionStudents(sectionId);
   const [showModal, setShowModal] = useState(ModalStates.NONE);
   const [focusedSpacetimeID, setFocusedSpacetimeID] = useState<number>(-1);
   const [userEmails, setUserEmails] = useState<string[]>([]);
@@ -67,7 +65,8 @@ export default function MentorSectionInfo({
       } Section`}</h3>
       <div className="section-info-cards-container">
         <InfoCard title="Students">
-          {!studentsLoading && (
+          {studentsLoaded ? (
+            // done loading
             <React.Fragment>
               <table id="students-table">
                 <thead>
@@ -76,7 +75,7 @@ export default function MentorSectionInfo({
                   </tr>
                 </thead>
                 <tbody>
-                  {(students!.length === 0 ? [{ name: "No students enrolled", email: "", id: -1 }] : students!).map(
+                  {(students.length === 0 ? [{ name: "No students enrolled", email: "", id: -1 }] : students).map(
                     ({ name, email, id: studentId }: Student) => (
                       <tr key={studentId}>
                         <td>
@@ -105,8 +104,10 @@ export default function MentorSectionInfo({
                 <CoordinatorAddStudentModal closeModal={closeAddModal} userEmails={userEmails} sectionId={sectionId} />
               )}
             </React.Fragment>
+          ) : (
+            // not done loading
+            <LoadingSpinner />
           )}
-          {studentsLoading && <LoadingSpinner />}
         </InfoCard>
         <div className="section-info-cards-right">
           {spacetimes.map(({ override, ...spacetime }, index) => (

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -121,7 +121,6 @@ export default function MentorSectionInfo({
                 <SpacetimeEditModal
                   key={spacetime.id}
                   sectionId={sectionId}
-                  reloadSection={reloadSection}
                   defaultSpacetime={spacetime}
                   closeModal={closeModal}
                   editingOverride={deleteType}
@@ -129,9 +128,9 @@ export default function MentorSectionInfo({
               )}
               {showModal === ModalStates.SPACETIME_DELETE && focusedSpacetimeID === spacetime.id && (
                 <SpacetimeDeleteModal
+                  sectionId={sectionId}
                   spacetimeId={spacetime.id}
                   closeModal={closeModal}
-                  reloadSection={reloadSection}
                   overrideDelete={deleteType}
                 />
               )}

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useSectionStudents } from "../../utils/queries/section";
+import { useSectionStudents } from "../../utils/queries/sections";
 import { Mentor, Spacetime, Student } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
 import { CoordinatorAddStudentModal } from "./CoordinatorAddStudentModal";

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -38,7 +38,7 @@ export default function MentorSectionInfo({
   id: sectionId,
   description
 }: MentorSectionInfoProps) {
-  const { data: students, isSuccess: studentsLoaded } = useSectionStudents(sectionId);
+  const { data: students, isSuccess: studentsLoaded, isError: studentsLoadError } = useSectionStudents(sectionId);
 
   const [showModal, setShowModal] = useState(ModalStates.NONE);
   const [focusedSpacetimeID, setFocusedSpacetimeID] = useState<number>(-1);
@@ -100,9 +100,12 @@ export default function MentorSectionInfo({
                 <CoordinatorAddStudentModal closeModal={closeAddModal} sectionId={sectionId} />
               )}
             </React.Fragment>
+          ) : studentsLoadError ? (
+            // error loading
+            <h3>Students could not be loaded</h3>
           ) : (
             // not done loading
-            <LoadingSpinner />
+            <LoadingSpinner className="spinner-centered" />
           )}
         </InfoCard>
         <div className="section-info-cards-right">

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -117,6 +117,7 @@ export default function MentorSectionInfo({
               {showModal === ModalStates.SPACETIME_EDIT && focusedSpacetimeID === spacetime.id && (
                 <SpacetimeEditModal
                   key={spacetime.id}
+                  sectionId={sectionId}
                   reloadSection={reloadSection}
                   defaultSpacetime={spacetime}
                   closeModal={closeModal}

--- a/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionInfo.tsx
@@ -1,16 +1,15 @@
-import React, { useEffect, useState } from "react";
-import { fetchJSON } from "../../utils/api";
+import React, { useState } from "react";
+import { useSectionStudents } from "../../utils/queries/section";
 import { Mentor, Spacetime, Student } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
-import { InfoCard, SectionSpacetime } from "./Section";
 import { CoordinatorAddStudentModal } from "./CoordinatorAddStudentModal";
+import MetaEditModal from "./MetaEditModal";
+import { InfoCard, SectionSpacetime } from "./Section";
 import SpacetimeEditModal from "./SpacetimeEditModal";
 import StudentDropper from "./StudentDropper";
 
 import XIcon from "../../../static/frontend/img/x.svg";
 import PencilIcon from "../../../static/frontend/img/pencil.svg";
-import MetaEditModal from "./MetaEditModal";
-import { useSectionStudents } from "../../utils/queries/section";
 import SpacetimeDeleteModal from "./SpacetimeDeleteModal";
 
 enum ModalStates {
@@ -40,24 +39,21 @@ export default function MentorSectionInfo({
   description
 }: MentorSectionInfoProps) {
   const { data: students, isSuccess: studentsLoaded } = useSectionStudents(sectionId);
+
   const [showModal, setShowModal] = useState(ModalStates.NONE);
   const [focusedSpacetimeID, setFocusedSpacetimeID] = useState<number>(-1);
-  const [userEmails, setUserEmails] = useState<string[]>([]);
   const [isAddingStudent, setIsAddingStudent] = useState<boolean>(false);
   const [deleteType, setDeleteType] = useState<boolean>(false);
-  useEffect(() => {
-    if (!isCoordinator) {
-      return;
-    }
-    fetchJSON("/users/").then(userEmails => setUserEmails(userEmails));
-  }, [sectionId, isCoordinator]);
+
   const closeModal = () => setShowModal(ModalStates.NONE);
+
   const closeAddModal = (reload = false) => {
     setIsAddingStudent(false);
     if (reload) {
       reloadSection();
     }
   };
+
   return (
     <React.Fragment>
       <h3 className="section-detail-page-title">{`${
@@ -101,7 +97,7 @@ export default function MentorSectionInfo({
                 </tbody>
               </table>
               {isCoordinator && isAddingStudent && (
-                <CoordinatorAddStudentModal closeModal={closeAddModal} userEmails={userEmails} sectionId={sectionId} />
+                <CoordinatorAddStudentModal closeModal={closeAddModal} sectionId={sectionId} />
               )}
             </React.Fragment>
           ) : (

--- a/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
@@ -3,25 +3,27 @@ import LoadingSpinner from "../LoadingSpinner";
 
 import CopyIcon from "../../../static/frontend/img/copy.svg";
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
-import { useSectionStudents } from "../../utils/query";
+import { useSectionStudents } from "../../utils/queries/section";
 
 interface MentorSectionRosterProps {
   id: number;
 }
 
 export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
-  const { data: students, isLoading: studentsLoading } = useSectionStudents(id);
+  const { data: students, isSuccess: studentsLoaded } = useSectionStudents(id);
   const [emailsCopied, setEmailsCopied] = useState(false);
   const handleCopyEmails = () => {
-    navigator.clipboard.writeText(students!.map(({ email }) => email).join("\n")).then(() => {
-      setEmailsCopied(true);
-      setTimeout(() => setEmailsCopied(false), 1500);
-    });
+    if (studentsLoaded) {
+      navigator.clipboard.writeText(students.map(({ email }) => email).join("\n")).then(() => {
+        setEmailsCopied(true);
+        setTimeout(() => setEmailsCopied(false), 1500);
+      });
+    }
   };
   return (
     <React.Fragment>
       <h3 className="section-detail-page-title">Roster</h3>
-      {!studentsLoading && (
+      {studentsLoaded ? (
         <table className="standalone-table">
           <thead>
             <tr>
@@ -34,7 +36,7 @@ export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
             </tr>
           </thead>
           <tbody>
-            {students!.map(({ name, email, id }) => (
+            {students.map(({ name, email, id }) => (
               <tr key={id}>
                 <td>{name}</td>
                 <td>{email}</td>
@@ -42,8 +44,9 @@ export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
             ))}
           </tbody>
         </table>
+      ) : (
+        <LoadingSpinner />
       )}
-      {studentsLoading && <LoadingSpinner />}
     </React.Fragment>
   );
 }

--- a/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
@@ -3,7 +3,7 @@ import LoadingSpinner from "../LoadingSpinner";
 
 import CopyIcon from "../../../static/frontend/img/copy.svg";
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
-import { useSectionStudents } from "../../utils/queries/section";
+import { useSectionStudents } from "../../utils/queries/sections";
 
 interface MentorSectionRosterProps {
   id: number;

--- a/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
@@ -10,7 +10,7 @@ interface MentorSectionRosterProps {
 }
 
 export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
-  const { data: students, isSuccess: studentsLoaded } = useSectionStudents(id);
+  const { data: students, isSuccess: studentsLoaded, isError: studentsLoadError } = useSectionStudents(id);
   const [emailsCopied, setEmailsCopied] = useState(false);
   const handleCopyEmails = () => {
     if (studentsLoaded) {
@@ -44,6 +44,8 @@ export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
             ))}
           </tbody>
         </table>
+      ) : studentsLoadError ? (
+        <h3>Students could not be loaded</h3>
       ) : (
         <LoadingSpinner />
       )}

--- a/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionRoster.tsx
@@ -1,19 +1,19 @@
 import React, { useState } from "react";
 import LoadingSpinner from "../LoadingSpinner";
-import { Student } from "../../utils/types";
 
 import CopyIcon from "../../../static/frontend/img/copy.svg";
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
+import { useSectionStudents } from "../../utils/query";
 
 interface MentorSectionRosterProps {
-  students: Student[];
-  loaded: boolean;
+  id: number;
 }
 
-export default function MentorSectionRoster({ students, loaded }: MentorSectionRosterProps) {
+export default function MentorSectionRoster({ id }: MentorSectionRosterProps) {
+  const { data: students, isLoading: studentsLoading } = useSectionStudents(id);
   const [emailsCopied, setEmailsCopied] = useState(false);
   const handleCopyEmails = () => {
-    navigator.clipboard.writeText(students.map(({ email }) => email).join("\n")).then(() => {
+    navigator.clipboard.writeText(students!.map(({ email }) => email).join("\n")).then(() => {
       setEmailsCopied(true);
       setTimeout(() => setEmailsCopied(false), 1500);
     });
@@ -21,7 +21,7 @@ export default function MentorSectionRoster({ students, loaded }: MentorSectionR
   return (
     <React.Fragment>
       <h3 className="section-detail-page-title">Roster</h3>
-      {loaded && (
+      {!studentsLoading && (
         <table className="standalone-table">
           <thead>
             <tr>
@@ -34,7 +34,7 @@ export default function MentorSectionRoster({ students, loaded }: MentorSectionR
             </tr>
           </thead>
           <tbody>
-            {students.map(({ name, email, id }) => (
+            {students!.map(({ name, email, id }) => (
               <tr key={id}>
                 <td>{name}</td>
                 <td>{email}</td>
@@ -43,7 +43,7 @@ export default function MentorSectionRoster({ students, loaded }: MentorSectionR
           </tbody>
         </table>
       )}
-      {!loaded && <LoadingSpinner />}
+      {studentsLoading && <LoadingSpinner />}
     </React.Fragment>
   );
 }

--- a/csm_web/frontend/src/components/section/MetaEditModal.tsx
+++ b/csm_web/frontend/src/components/section/MetaEditModal.tsx
@@ -16,7 +16,7 @@ export default function MetaEditModal({
   reloadSection,
   capacity,
   description
-}: MetaEditModalProps) {
+}: MetaEditModalProps): React.ReactElement {
   // use existing capacity and description as initial values
   const [formState, setFormState] = useState({ capacity: capacity, description: description });
 

--- a/csm_web/frontend/src/components/section/MetaEditModal.tsx
+++ b/csm_web/frontend/src/components/section/MetaEditModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
+import { useSectionUpdateMutation } from "../../utils/queries/sections";
 import Modal from "../Modal";
 
 interface MetaEditModalProps {
@@ -20,6 +20,8 @@ export default function MetaEditModal({
   // use existing capacity and description as initial values
   const [formState, setFormState] = useState({ capacity: capacity, description: description });
 
+  const sectionUpdateMutation = useSectionUpdateMutation(sectionId);
+
   function handleChange({ target: { name, value } }: React.ChangeEvent<HTMLInputElement>) {
     setFormState(prevFormState => ({ ...prevFormState, [name]: value }));
   }
@@ -27,10 +29,9 @@ export default function MetaEditModal({
   function handleSubmit(event: React.ChangeEvent<HTMLFormElement>) {
     event.preventDefault();
     //TODO: Handle API Failure
-    fetchWithMethod(`/sections/${sectionId}/`, HTTP_METHODS.PATCH, formState).then(() => {
-      closeModal();
-      reloadSection();
-    });
+    sectionUpdateMutation.mutate(formState);
+    closeModal();
+    reloadSection();
   }
 
   return (

--- a/csm_web/frontend/src/components/section/Section.tsx
+++ b/csm_web/frontend/src/components/section/Section.tsx
@@ -13,7 +13,7 @@ export default function Section(): React.ReactElement | null {
   const { id } = useParams();
   const queryClient = useQueryClient();
 
-  const { data: section, isSuccess: sectionLoaded } = useSection(Number(id));
+  const { data: section, isSuccess: sectionLoaded, isError: sectionLoadError } = useSection(Number(id));
 
   /**
    * TODO: completely remove this function after migrating all requests to react-query
@@ -24,6 +24,9 @@ export default function Section(): React.ReactElement | null {
   };
 
   if (!sectionLoaded) {
+    if (sectionLoadError) {
+      return <h3>Section not found</h3>;
+    }
     return <LoadingSpinner className="spinner-centered" />;
   }
 

--- a/csm_web/frontend/src/components/section/Section.tsx
+++ b/csm_web/frontend/src/components/section/Section.tsx
@@ -3,7 +3,7 @@ import { NavLink, useParams } from "react-router-dom";
 import StudentSection from "./StudentSection";
 import MentorSection from "./MentorSection";
 import { Override, Spacetime } from "../../utils/types";
-import { useSection } from "../../utils/queries/section";
+import { useSection } from "../../utils/queries/sections";
 import { useQueryClient } from "@tanstack/react-query";
 import LoadingSpinner from "../LoadingSpinner";
 

--- a/csm_web/frontend/src/components/section/Section.tsx
+++ b/csm_web/frontend/src/components/section/Section.tsx
@@ -3,8 +3,9 @@ import { NavLink, useParams } from "react-router-dom";
 import StudentSection from "./StudentSection";
 import MentorSection from "./MentorSection";
 import { Override, Spacetime } from "../../utils/types";
-import { useSection } from "../../utils/query";
-import { useQueryClient } from "react-query";
+import { useSection } from "../../utils/queries/section";
+import { useQueryClient } from "@tanstack/react-query";
+import LoadingSpinner from "../LoadingSpinner";
 
 export const ROLES = Object.freeze({ COORDINATOR: "COORDINATOR", STUDENT: "STUDENT", MENTOR: "MENTOR" });
 
@@ -12,25 +13,24 @@ export default function Section(): React.ReactElement | null {
   const { id } = useParams();
   const queryClient = useQueryClient();
 
-  const { data: section, isLoading: sectionLoading } = useSection(Number(id));
+  const { data: section, isSuccess: sectionLoaded } = useSection(Number(id));
 
   /**
    * TODO: completely remove this function after migrating all requests to react-query
    */
   const reloadSection = () => {
     console.log("reloading section");
-    queryClient.invalidateQueries(["sections", Number(id)], { refetchInactive: true });
+    queryClient.invalidateQueries(["sections", Number(id)], { refetchType: "all" });
   };
 
-  if (sectionLoading) {
-    return null;
+  if (!sectionLoaded) {
+    return <LoadingSpinner className="spinner-centered" />;
   }
-  switch (
-    section!.userRole // section can't be null here because loaded would be false
-  ) {
+
+  switch (section.userRole) {
     case ROLES.COORDINATOR:
     case ROLES.MENTOR:
-      return <MentorSection reloadSection={reloadSection} id={Number(id)} {...section} />;
+      return <MentorSection reloadSection={reloadSection} {...section} />;
     case ROLES.STUDENT:
       return <StudentSection {...section} />;
   }

--- a/csm_web/frontend/src/components/section/SpacetimeDeleteModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeDeleteModal.tsx
@@ -1,29 +1,32 @@
 import React, { useState } from "react";
-import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
-import { Override, Section as SectionType, Spacetime } from "../../utils/types";
+import { useSpacetimeDeleteMutation, useSpacetimeOverrideDeleteMutation } from "../../utils/queries/spacetime";
 import Modal from "../Modal";
 
 interface SpacetimeDeleteProps {
   spacetimeId: number;
+  sectionId: number;
   overrideDelete: boolean;
   closeModal: () => void;
-  reloadSection: () => void;
 }
 
 export default function SpacetimeDeleteModal({
   closeModal,
   spacetimeId,
-  reloadSection,
+  sectionId,
   overrideDelete
 }: SpacetimeDeleteProps) {
   const [drop, setDrop] = useState(false);
 
+  const spacetimeDeleteMutation = useSpacetimeDeleteMutation(sectionId, spacetimeId);
+  const spacetimeOverrideDeleteMutation = useSpacetimeOverrideDeleteMutation(sectionId, spacetimeId);
+
   function handleClickDrop() {
     if (overrideDelete) {
-      fetchWithMethod(`spacetimes/${spacetimeId}/override/`, HTTP_METHODS.DELETE).then(() => reloadSection());
+      spacetimeOverrideDeleteMutation.mutate();
     } else {
-      fetchWithMethod(`spacetimes/${spacetimeId}/`, HTTP_METHODS.DELETE).then(() => reloadSection());
+      spacetimeDeleteMutation.mutate();
     }
+    closeModal();
   }
 
   return (

--- a/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
 import { Spacetime } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
@@ -13,55 +13,25 @@ interface SpacetimeEditModalProps {
   editingOverride: boolean;
 }
 
-interface SpacetimeEditModalState {
-  location: Spacetime["location"];
-  day: Spacetime["dayOfWeek"];
-  time: Spacetime["time"];
-  isPermanent: boolean;
-  changeDate: string;
-  mode: string;
-  showSaveSpinner: boolean;
-}
+const SpaceTimeEditModal = ({
+  closeModal,
+  defaultSpacetime: { id: spacetimeId, startTime: timeString, location: prevLocation, dayOfWeek },
+  reloadSection,
+  editingOverride
+}: SpacetimeEditModalProps): React.ReactElement => {
+  const sliceIndex = timeString.split(":").length < 3 ? timeString.indexOf(":") : timeString.lastIndexOf(":");
+  const [location, setLocation] = useState<Spacetime["location"]>(prevLocation);
+  const [day, setDay] = useState<Spacetime["dayOfWeek"]>(dayOfWeek);
+  const [time, setTime] = useState<Spacetime["time"]>(timeString.slice(0, sliceIndex));
+  const [isPermanent, setIsPermanent] = useState<boolean>(false);
+  const [date, setDate] = useState<string>("");
+  const [mode, setMode] = useState<string>(prevLocation && prevLocation.startsWith("http") ? "virtual" : "inperson");
+  const [showSaveSpinner, setShowSaveSpinner] = useState<boolean>(false);
 
-export default class SpacetimeEditModal extends React.Component<SpacetimeEditModalProps, SpacetimeEditModalState> {
-  constructor(props: SpacetimeEditModalProps) {
-    super(props);
-    // Time string comes as HH:MM:ss, TimeInput expects HH:MM
-    const timeString = props.defaultSpacetime.startTime;
-    // Some extra logic in case the API changes to HH:MM,
-    // in which case split would produce 2 segments instead of 3
-    const sliceIndex = timeString.split(":").length < 3 ? timeString.indexOf(":") : timeString.lastIndexOf(":");
-    this.state = {
-      location: props.defaultSpacetime.location,
-      day: props.defaultSpacetime.dayOfWeek,
-      time: timeString.slice(0, sliceIndex),
-      isPermanent: false,
-      changeDate: "",
-      // Logic to determine whether or not the location is virtual or in person (same logic as backend to omit video call links)
-      mode:
-        props.defaultSpacetime.location && props.defaultSpacetime.location.startsWith("http") ? "virtual" : "inperson",
-      showSaveSpinner: false
-    };
-    this.handleChange = this.handleChange.bind(this);
-    this.handleChangeSelect = this.handleChangeSelect.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
-  }
-
-  handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    this.setState(state => ({ ...state, [e.target.name]: e.target.value }));
-  }
-
-  handleChangeSelect(e: React.ChangeEvent<HTMLSelectElement>) {
-    this.setState(state => ({ ...state, [e.target.name]: e.target.value }));
-  }
-
-  handleSubmit(e: React.ChangeEvent<HTMLFormElement>) {
+  const handleSubmit = (e: React.ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const { closeModal, defaultSpacetime, reloadSection } = this.props;
-    const spacetimeId = defaultSpacetime.id;
-    const { location, day, time, isPermanent, changeDate } = this.state;
     //TODO: Handle API failure
-    this.setState({ showSaveSpinner: true });
+    setShowSaveSpinner(true);
     (isPermanent
       ? fetchWithMethod(`/spacetimes/${spacetimeId}/modify`, HTTP_METHODS.PUT, {
           day_of_week: day,
@@ -71,138 +41,136 @@ export default class SpacetimeEditModal extends React.Component<SpacetimeEditMod
       : fetchWithMethod(`/spacetimes/${spacetimeId}/override`, HTTP_METHODS.PUT, {
           location: location,
           start_time: `${time}:00`,
-          date: changeDate
+          date: date
         })
     ).then(() => {
       closeModal();
       reloadSection();
     });
-  }
+  };
 
-  render(): React.ReactElement {
-    const { location, day, time, isPermanent, changeDate, mode, showSaveSpinner } = this.state;
-    const now = new Date();
-    const today = `${now.getFullYear()}-${zeroPadTwoDigit(now.getMonth() + 1)}-${zeroPadTwoDigit(now.getDate())}`;
-    return (
-      <Modal className="spacetime-edit-modal" closeModal={this.props.closeModal}>
-        <form className="csm-form" id="spacetime-edit-form" onSubmit={this.handleSubmit}>
-          <h4>Change Time and Location</h4>
-          <div className="mode-selection">
-            <label>Section is</label>
-            <div className="mode-selection-options">
-              <label>
-                <input
-                  onChange={this.handleChange}
-                  type="radio"
-                  name="mode"
-                  value="inperson"
-                  checked={mode === "inperson"}
-                />
-                In person
-              </label>
-              <label>
-                <input
-                  onChange={this.handleChange}
-                  type="radio"
-                  name="mode"
-                  value="virtual"
-                  checked={mode === "virtual"}
-                />
-                Virtual
-              </label>
-            </div>
+  const now = new Date();
+  const today = `${now.getFullYear()}-${zeroPadTwoDigit(now.getMonth() + 1)}-${zeroPadTwoDigit(now.getDate())}`;
+
+  return (
+    <Modal className="spacetime-edit-modal" closeModal={closeModal}>
+      <form className="csm-form" id="spacetime-edit-form" onSubmit={handleSubmit}>
+        <h4>Change Time and Location</h4>
+        <div className="mode-selection">
+          <label>Section is</label>
+          <div className="mode-selection-options">
+            <label>
+              <input
+                onChange={e => setMode(e.target.value)}
+                type="radio"
+                name="mode"
+                value="inperson"
+                checked={mode === "inperson"}
+              />
+              In person
+            </label>
+            <label>
+              <input
+                onChange={e => setMode(e.target.value)}
+                type="radio"
+                name="mode"
+                value="virtual"
+                checked={mode === "virtual"}
+              />
+              Virtual
+            </label>
           </div>
+        </div>
+        <label>
+          {mode === "inperson" ? "Location" : "Video Call Link"}
+          <input
+            onChange={e => setLocation(e.target.value)}
+            required
+            title="You cannot leave this field blank"
+            pattern=".*[^\s]+.*"
+            type={mode === "inperson" ? "text" : "url"}
+            maxLength={200}
+            name="location"
+            value={location}
+            autoFocus
+          />
+        </label>
+        {/* Would use a fieldset to be semantic, but Chrome has a bug where flexbox doesn't work for fieldset */}
+        <div id="day-time-fields">
           <label>
-            {mode === "inperson" ? "Location" : "Video Call Link"}
-            <input
-              onChange={this.handleChange}
-              required
-              title="You cannot leave this field blank"
-              pattern=".*[^\s]+.*"
-              type={mode === "inperson" ? "text" : "url"}
-              maxLength={200}
-              name="location"
-              value={location}
-              autoFocus
-            />
+            Day
+            <select
+              onChange={e => setDay(e.target.value)}
+              required={!!isPermanent}
+              name="day"
+              disabled={!isPermanent}
+              value={isPermanent ? day : "---"}
+            >
+              {["---"].concat(Array.from(DAYS_OF_WEEK)).map(value => (
+                <option key={value} value={value} disabled={value === "---"}>
+                  {value}
+                </option>
+              ))}
+            </select>
           </label>
-          {/* Would use a fieldset to be semantic, but Chrome has a bug where flexbox doesn't work for fieldset */}
-          <div id="day-time-fields">
-            <label>
-              Day
-              <select
-                onChange={this.handleChangeSelect}
-                required={!!isPermanent}
-                name="day"
-                disabled={!isPermanent}
-                value={isPermanent ? day : "---"}
-              >
-                {["---"].concat(Array.from(DAYS_OF_WEEK)).map(value => (
-                  <option key={value} value={value} disabled={value === "---"}>
-                    {value}
-                  </option>
-                ))}
-              </select>
-            </label>
-            <label>
-              Time
-              <TimeInput onChange={this.handleChange} required name="time" value={time} />
-            </label>
-          </div>
-          <div id="date-of-change-fields">
-            <label>Change for</label>
-            {!this.props.editingOverride && (
-              <React.Fragment>
-                <label>
-                  <input
-                    onChange={this.handleChange}
-                    required
-                    type="radio"
-                    name="isPermanent"
-                    checked={!!isPermanent}
-                    value="true"
-                  />
-                  All sections
-                </label>
+          <label>
+            Time
+            <TimeInput onChange={e => setTime(e.currentTarget.value)} required name="time" value={time} />
+          </label>
+        </div>
+        <div id="date-of-change-fields">
+          <label>Change for</label>
+          {!editingOverride && (
+            <React.Fragment>
+              <label>
                 <input
-                  onChange={this.handleChange}
+                  onChange={e => setIsPermanent(e.target.checked)}
                   required
                   type="radio"
                   name="isPermanent"
-                  checked={!isPermanent}
-                  value=""
+                  checked={!!isPermanent}
+                  value="true"
                 />
-                <input
-                  onChange={this.handleChange}
-                  required={!isPermanent}
-                  type="date"
-                  min={today}
-                  name="changeDate"
-                  disabled={!!isPermanent}
-                  value={isPermanent ? "" : changeDate}
-                />
-                <label></label>
-              </React.Fragment>
-            )}
-            {this.props.editingOverride && (
-              <React.Fragment>
-                <input
-                  onChange={this.handleChange}
-                  required={!isPermanent}
-                  type="date"
-                  min={today}
-                  name="changeDate"
-                  disabled={!!isPermanent}
-                  value={isPermanent ? "" : changeDate}
-                />
-              </React.Fragment>
-            )}
-          </div>
-          <div id="submit-and-status">
-            {showSaveSpinner ? <LoadingSpinner /> : <input type="submit" value="Save" />}
-          </div>
-        </form>
-      </Modal>
-    );
-  }
-}
+                All sections
+              </label>
+              <input
+                onChange={e => setIsPermanent(!e.target.checked)}
+                required
+                type="radio"
+                name="isPermanent"
+                checked={!isPermanent}
+                value=""
+              />
+              <input
+                onChange={e => setDate(e.target.value)}
+                required={!isPermanent}
+                type="date"
+                min={today}
+                name="changeDate"
+                disabled={!!isPermanent}
+                value={isPermanent ? "" : date}
+              />
+              <label></label>
+            </React.Fragment>
+          )}
+          {editingOverride && (
+            <React.Fragment>
+              <input
+                onChange={e => setDate(e.target.value)}
+                required={!isPermanent}
+                type="date"
+                min={today}
+                name="changeDate"
+                disabled={!!isPermanent}
+                value={isPermanent ? "" : date}
+              />
+            </React.Fragment>
+          )}
+        </div>
+        <div id="submit-and-status">{showSaveSpinner ? <LoadingSpinner /> : <input type="submit" value="Save" />}</div>
+      </form>
+    </Modal>
+  );
+};
+
+export default SpaceTimeEditModal;

--- a/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
@@ -10,7 +10,6 @@ interface SpacetimeEditModalProps {
   sectionId: number;
   closeModal: () => void;
   defaultSpacetime: Spacetime;
-  reloadSection: () => void;
   editingOverride: boolean;
 }
 
@@ -18,7 +17,6 @@ const SpaceTimeEditModal = ({
   sectionId,
   closeModal,
   defaultSpacetime: { id: spacetimeId, startTime: timeString, location: prevLocation, dayOfWeek },
-  reloadSection,
   editingOverride
 }: SpacetimeEditModalProps): React.ReactElement => {
   const sliceIndex = timeString.split(":").length < 3 ? timeString.indexOf(":") : timeString.lastIndexOf(":");
@@ -49,7 +47,6 @@ const SpaceTimeEditModal = ({
           date: date
         });
     closeModal();
-    reloadSection();
   };
 
   const now = new Date();

--- a/csm_web/frontend/src/components/section/StudentDropper.tsx
+++ b/csm_web/frontend/src/components/section/StudentDropper.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { useStudentDropMutation } from "../../utils/queries/section";
+import { useDropStudentMutation } from "../../utils/queries/sections";
 import Modal from "../Modal";
 
 interface StudentDropperProps {
@@ -16,7 +16,7 @@ export default function StudentDropper({ id, sectionId, name }: StudentDropperPr
   /**
    * Mutation to drop a student from the section.
    */
-  const studentDropMutation = useStudentDropMutation(id, sectionId);
+  const studentDropMutation = useDropStudentMutation(id, sectionId);
 
   function handleClickDrop() {
     studentDropMutation.mutate({ banned: ban });

--- a/csm_web/frontend/src/components/section/StudentDropper.tsx
+++ b/csm_web/frontend/src/components/section/StudentDropper.tsx
@@ -13,10 +13,13 @@ export default function StudentDropper({ id, sectionId, name }: StudentDropperPr
   const [drop, setDrop] = useState(false);
   const [ban, setBan] = useState(false);
 
-  const studentDropMutate = useStudentDropMutation(id, sectionId);
+  /**
+   * Mutation to drop a student from the section.
+   */
+  const studentDropMutation = useStudentDropMutation(id, sectionId);
 
   function handleClickDrop() {
-    studentDropMutate.mutate({ banned: ban });
+    studentDropMutation.mutate({ banned: ban });
     setShowDropPrompt(false);
   }
 

--- a/csm_web/frontend/src/components/section/StudentDropper.tsx
+++ b/csm_web/frontend/src/components/section/StudentDropper.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from "react";
-import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
-import { useStudentDropMutation } from "../../utils/query";
+import { useStudentDropMutation } from "../../utils/queries/section";
 import Modal from "../Modal";
 
 interface StudentDropperProps {

--- a/csm_web/frontend/src/components/section/StudentDropper.tsx
+++ b/csm_web/frontend/src/components/section/StudentDropper.tsx
@@ -1,20 +1,24 @@
 import React, { useState } from "react";
 import { fetchWithMethod, HTTP_METHODS } from "../../utils/api";
+import { useStudentDropMutation } from "../../utils/query";
 import Modal from "../Modal";
 
 interface StudentDropperProps {
   id: number;
+  sectionId: number;
   name: string;
-  reloadSection: () => void;
 }
 
-export default function StudentDropper({ id, name, reloadSection }: StudentDropperProps) {
+export default function StudentDropper({ id, sectionId, name }: StudentDropperProps) {
   const [showDropPrompt, setShowDropPrompt] = useState(false);
   const [drop, setDrop] = useState(false);
   const [ban, setBan] = useState(false);
 
+  const studentDropMutate = useStudentDropMutation(id, sectionId);
+
   function handleClickDrop() {
-    fetchWithMethod(`students/${id}/drop`, HTTP_METHODS.PATCH, { banned: ban }).then(() => reloadSection());
+    studentDropMutate.mutate({ banned: ban });
+    setShowDropPrompt(false);
   }
 
   return (

--- a/csm_web/frontend/src/components/section/StudentSection.tsx
+++ b/csm_web/frontend/src/components/section/StudentSection.tsx
@@ -6,6 +6,7 @@ import Modal from "../Modal";
 import { ATTENDANCE_LABELS, InfoCard, ROLES, SectionDetail, SectionSpacetime } from "./Section";
 
 import XIcon from "../../../static/frontend/img/x.svg";
+import LoadingSpinner from "../LoadingSpinner";
 
 interface StudentSectionType {
   course: string;
@@ -139,9 +140,11 @@ interface StudentSectionAttendanceProps {
 }
 
 function StudentSectionAttendance({ associatedProfileId }: StudentSectionAttendanceProps) {
-  const { data: attendances, isSuccess: attendancesLoaded } = useStudentAttendances(associatedProfileId);
+  const { data: attendances, isSuccess: attendancesLoaded, isError: attendancesLoadError } = useStudentAttendances(
+    associatedProfileId
+  );
 
-  return !attendancesLoaded ? null : (
+  return attendancesLoaded ? (
     <table id="attendance-table" className="standalone-table">
       <thead>
         <tr>
@@ -163,5 +166,9 @@ function StudentSectionAttendance({ associatedProfileId }: StudentSectionAttenda
         })}
       </tbody>
     </table>
+  ) : attendancesLoadError ? (
+    <h3>Attendances could not be loaded</h3>
+  ) : (
+    <LoadingSpinner className="spinner-centered" />
   );
 }

--- a/csm_web/frontend/src/index.tsx
+++ b/csm_web/frontend/src/index.tsx
@@ -2,12 +2,28 @@ import App from "./components/App";
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+import { ReactQueryDevtools } from "react-query/devtools";
+
+// react-query setup
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // 5 minute stale time
+      staleTime: 1000 * 60 * 5
+    }
+  }
+});
 
 const root = createRoot(document.getElementById("app") as HTMLElement);
 root.render(
   <React.StrictMode>
     <Router>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+        <ReactQueryDevtools />
+      </QueryClientProvider>
     </Router>
   </React.StrictMode>
 );

--- a/csm_web/frontend/src/index.tsx
+++ b/csm_web/frontend/src/index.tsx
@@ -2,9 +2,9 @@ import App from "./components/App";
 import React from "react";
 import { BrowserRouter as Router } from "react-router-dom";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
-import { ReactQueryDevtools } from "react-query/devtools";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 // react-query setup
 const queryClient = new QueryClient({

--- a/csm_web/frontend/src/utils/api.tsx
+++ b/csm_web/frontend/src/utils/api.tsx
@@ -48,6 +48,13 @@ export function fetchWithMethod(endpoint: string, method: string, data: any = {}
   });
 }
 
+/**
+ * Fetch data from normalized endpoint.
+ */
+export async function fetchNormalized(endpoint: string) {
+  return await fetch(normalizeEndpoint(endpoint), { credentials: "same-origin" });
+}
+
 export async function fetchJSON(endpoint: string) {
   const response = await fetch(normalizeEndpoint(endpoint), { credentials: "same-origin" });
   return await response.json();

--- a/csm_web/frontend/src/utils/queries/base.tsx
+++ b/csm_web/frontend/src/utils/queries/base.tsx
@@ -1,0 +1,65 @@
+/**
+ * All query hooks follow the same procedure:
+ * - Fetch the data from the backend API
+ * - If an error occurs, throw the error with some additional details
+ * - Otherwise, return the QueryResult object
+ *
+ * There is no need for error handling in the frontend;
+ * the error boundary in App.tsx will catch any errors and display a friendly error page.
+ */
+
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { fetchNormalized } from "../api";
+import { Course, Profile, RawUserInfo } from "../types";
+import { handleError, ServerError } from "./helpers";
+
+/**
+ * Hook to get the user's profile list.
+ */
+export const useProfiles = (): UseQueryResult<Profile[], ServerError> => {
+  const queryResult = useQuery<Profile[], ServerError>(["profiles"], async () => {
+    const response = await fetchNormalized("/profiles");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch profiles");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/**
+ * Hook to get all courses.
+ */
+export const useCourses = (): UseQueryResult<Course[], ServerError> => {
+  const queryResult = useQuery<Course[], Error>(["courses"], async () => {
+    const response = await fetchNormalized("/courses");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch courses");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/**
+ * Hook to get the user's info.
+ */
+export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
+  const queryResult = useQuery<RawUserInfo, Error>(["userinfo"], async () => {
+    const response = await fetchNormalized("/userinfo");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch user info");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};

--- a/csm_web/frontend/src/utils/queries/base.tsx
+++ b/csm_web/frontend/src/utils/queries/base.tsx
@@ -11,20 +11,25 @@
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { fetchNormalized } from "../api";
 import { Profile, RawUserInfo } from "../types";
-import { handleError, ServerError } from "./helpers";
+import { handleError, handlePermissionsError, handleRetry, ServerError } from "./helpers";
 
 /**
  * Hook to get the user's profile list.
  */
-export const useProfiles = (): UseQueryResult<Profile[], ServerError> => {
-  const queryResult = useQuery<Profile[], ServerError>(["profiles"], async () => {
-    const response = await fetchNormalized("/profiles");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch profiles");
-    }
-  });
+export const useProfiles = (): UseQueryResult<Profile[], Error> => {
+  const queryResult = useQuery<Profile[], Error>(
+    ["profiles"],
+    async () => {
+      const response = await fetchNormalized("/profiles");
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError("Failed to fetch profiles");
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -33,15 +38,20 @@ export const useProfiles = (): UseQueryResult<Profile[], ServerError> => {
 /**
  * Hook to get the user's info.
  */
-export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
-  const queryResult = useQuery<RawUserInfo, Error>(["userinfo"], async () => {
-    const response = await fetchNormalized("/userinfo");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch user info");
-    }
-  });
+export const useUserInfo = (): UseQueryResult<RawUserInfo, Error> => {
+  const queryResult = useQuery<RawUserInfo, Error>(
+    ["userinfo"],
+    async () => {
+      const response = await fetchNormalized("/userinfo");
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError("Failed to fetch user info");
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -50,15 +60,20 @@ export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
 /**
  * Hook to get a list of all user emails.
  */
-export const useUserEmails = (): UseQueryResult<string[], ServerError> => {
-  const queryResult = useQuery<string[], Error>(["users"], async () => {
-    const response = await fetchNormalized("/users");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch user info");
-    }
-  });
+export const useUserEmails = (): UseQueryResult<string[], Error> => {
+  const queryResult = useQuery<string[], Error>(
+    ["users"],
+    async () => {
+      const response = await fetchNormalized("/users");
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError("Failed to fetch user info");
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;

--- a/csm_web/frontend/src/utils/queries/base.tsx
+++ b/csm_web/frontend/src/utils/queries/base.tsx
@@ -10,7 +10,7 @@
 
 import { useQuery, UseQueryResult } from "@tanstack/react-query";
 import { fetchNormalized } from "../api";
-import { Course, Profile, RawUserInfo } from "../types";
+import { Profile, RawUserInfo } from "../types";
 import { handleError, ServerError } from "./helpers";
 
 /**
@@ -31,15 +31,15 @@ export const useProfiles = (): UseQueryResult<Profile[], ServerError> => {
 };
 
 /**
- * Hook to get all courses.
+ * Hook to get the user's info.
  */
-export const useCourses = (): UseQueryResult<Course[], ServerError> => {
-  const queryResult = useQuery<Course[], Error>(["courses"], async () => {
-    const response = await fetchNormalized("/courses");
+export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
+  const queryResult = useQuery<RawUserInfo, Error>(["userinfo"], async () => {
+    const response = await fetchNormalized("/userinfo");
     if (response.ok) {
       return await response.json();
     } else {
-      throw new ServerError("Failed to fetch courses");
+      throw new ServerError("Failed to fetch user info");
     }
   });
 
@@ -48,11 +48,11 @@ export const useCourses = (): UseQueryResult<Course[], ServerError> => {
 };
 
 /**
- * Hook to get the user's info.
+ * Hook to get a list of all user emails.
  */
-export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
-  const queryResult = useQuery<RawUserInfo, Error>(["userinfo"], async () => {
-    const response = await fetchNormalized("/userinfo");
+export const useUserEmails = (): UseQueryResult<string[], ServerError> => {
+  const queryResult = useQuery<string[], Error>(["users"], async () => {
+    const response = await fetchNormalized("/users");
     if (response.ok) {
       return await response.json();
     } else {

--- a/csm_web/frontend/src/utils/queries/course.tsx
+++ b/csm_web/frontend/src/utils/queries/course.tsx
@@ -1,0 +1,53 @@
+/**
+ * Query hooks regarding courses.
+ */
+
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { fetchNormalized } from "../api";
+import { Course, Section } from "../types";
+import { handleError, ServerError } from "./helpers";
+
+/**
+ * Hook to get all courses.
+ */
+export const useCourses = (): UseQueryResult<Course[], ServerError> => {
+  const queryResult = useQuery<Course[], Error>(["courses"], async () => {
+    const response = await fetchNormalized("/courses");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch courses");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface CourseSectionsQueryResponse {
+  sections: { [day: string]: Section[] };
+  userIsCoordinator: boolean;
+}
+
+/**
+ * Hook to get all sections for a course.
+ */
+export const useCourseSections = (id?: number): UseQueryResult<CourseSectionsQueryResponse, ServerError> => {
+  const queryResult = useQuery<CourseSectionsQueryResponse, Error>(
+    ["courses", id, "sections"],
+    async () => {
+      const response = await fetchNormalized(`/courses/${id}/sections`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        throw new ServerError(`Failed to fetch course ${id} sections`);
+      }
+    },
+    {
+      enabled: !!id
+    }
+  );
+
+  handleError(queryResult);
+  return queryResult;
+};

--- a/csm_web/frontend/src/utils/queries/courses.tsx
+++ b/csm_web/frontend/src/utils/queries/courses.tsx
@@ -32,7 +32,10 @@ interface CourseSectionsQueryResponse {
 /**
  * Hook to get all sections for a course.
  */
-export const useCourseSections = (id?: number): UseQueryResult<CourseSectionsQueryResponse, ServerError> => {
+export const useCourseSections = (
+  id: number | undefined,
+  onSuccess?: (response: CourseSectionsQueryResponse) => void
+): UseQueryResult<CourseSectionsQueryResponse, ServerError> => {
   const queryResult = useQuery<CourseSectionsQueryResponse, Error>(
     ["courses", id, "sections"],
     async () => {
@@ -44,7 +47,8 @@ export const useCourseSections = (id?: number): UseQueryResult<CourseSectionsQue
       }
     },
     {
-      enabled: !!id
+      enabled: !!id,
+      onSuccess: onSuccess
     }
   );
 

--- a/csm_web/frontend/src/utils/queries/helpers.tsx
+++ b/csm_web/frontend/src/utils/queries/helpers.tsx
@@ -1,0 +1,28 @@
+/**
+ * Helper functions for query hooks.
+ */
+
+import { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
+
+/**
+ * Derived class of Error for internal server errors.
+ */
+export class ServerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ServerError";
+  }
+}
+
+/**
+ * Handle errors from the backend API, if any occur.
+ * If no error, nothing happens.
+ */
+export const handleError = (
+  result: UseQueryResult<any, ServerError> | UseMutationResult<any, ServerError, any>
+): void => {
+  if (result.isError) {
+    const failures = result.failureCount;
+    throw new ServerError(`${result.error.message} (${failures} failures)`);
+  }
+};

--- a/csm_web/frontend/src/utils/queries/helpers.tsx
+++ b/csm_web/frontend/src/utils/queries/helpers.tsx
@@ -4,6 +4,8 @@
 
 import { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
 
+const MAX_RETRIES = 3;
+
 /**
  * Derived class of Error for internal server errors.
  */
@@ -15,14 +17,59 @@ export class ServerError extends Error {
 }
 
 /**
+ * Derived class of Error for permissions-related errors.
+ * This includes unauthorized access, forbidden access, and not found errors.
+ */
+export class PermissionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PermissionError";
+  }
+}
+
+/**
+ * Helper function to check if a status code is a permissions error.
+ * This is used to tell whether we should retry the request.
+ *
+ * @param status HTTP status code
+ * @returns whether the status code is a client error
+ */
+export const handlePermissionsError = (status: number) => {
+  if (status >= 400 && status < 500) {
+    // client error (4xx)
+    throw new PermissionError("You do not have permission to perform this action.");
+  }
+  // otherwise, fall through
+};
+
+/**
  * Handle errors from the backend API, if any occur.
  * If no error, nothing happens.
  */
-export const handleError = (
-  result: UseQueryResult<any, ServerError> | UseMutationResult<any, ServerError, any>
-): void => {
+export const handleError = (result: UseQueryResult<any, Error> | UseMutationResult<any, Error, any>): void => {
   if (result.isError) {
-    const failures = result.failureCount;
-    throw new ServerError(`${result.error.message} (${failures} failures)`);
+    if (result.error instanceof PermissionError) {
+      // permissions error; do nothing, and let the component handle it
+    } else {
+      // otherwise, throw the error
+      const failures = result.failureCount;
+      throw new ServerError(`${result.error.message} (${failures} failures)`);
+    }
   }
+};
+
+/**
+ * Helper function to determine whether a query should be retried.
+ */
+export const handleRetry = (failureCount: number, error: Error) => {
+  if (failureCount > MAX_RETRIES) {
+    return false;
+  } else if (error instanceof ServerError) {
+    return true;
+  } else if (error instanceof PermissionError) {
+    return false;
+  }
+
+  // if anything else, retry
+  return true;
 };

--- a/csm_web/frontend/src/utils/queries/matcher.tsx
+++ b/csm_web/frontend/src/utils/queries/matcher.tsx
@@ -1,0 +1,381 @@
+/**
+ * Query hooks regarding the matcher.
+ */
+
+import {
+  QueryClient,
+  useMutation,
+  UseMutationResult,
+  useQuery,
+  useQueryClient,
+  UseQueryResult
+} from "@tanstack/react-query";
+import { Assignment, Slot } from "../../components/enrollment_automation/EnrollmentAutomationTypes";
+import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
+import { Mentor } from "../types";
+import { handleError, ServerError } from "./helpers";
+
+/* ==== Queries ===== */
+
+export const useMatcherActiveCourses = (): UseQueryResult<number[], ServerError> => {
+  const queryResult = useQuery<number[], Error>(["matcher", "active"], async () => {
+    const response = await fetchNormalized("/matcher/active");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch active matcher courses");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface MatcherSlotsResponse {
+  slots: Array<{
+    id: number;
+    times: MatcherSlotsResponseTime[];
+  }>;
+}
+
+/**
+ * Variant on Time interface with string times
+ */
+interface MatcherSlotsResponseTime {
+  day: string;
+  startTime: string;
+  endTime: string;
+  isLinked: boolean;
+}
+
+/**
+ * Hook to fetch the matcher slots for a given course.
+ */
+export const useMatcherSlots = (courseId: number): UseQueryResult<MatcherSlotsResponse, ServerError> => {
+  const queryResult = useQuery<MatcherSlotsResponse, Error>(["matcher", courseId, "slots"], async () => {
+    const response = await fetchNormalized(`/matcher/${courseId}/slots`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch matcher slots for course ${courseId}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface MatcherPreferencesResponse {
+  responses: Array<{ slot: number; mentor: number; preference: number }>;
+}
+
+export const useMatcherPreferences = (courseId: number): UseQueryResult<MatcherPreferencesResponse, ServerError> => {
+  const queryResult = useQuery<MatcherPreferencesResponse, Error>(["matcher", courseId, "preferences"], async () => {
+    const response = await fetchNormalized(`/matcher/${courseId}/preferences`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch matcher preferences");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface MatcherConfigResponse {
+  open: boolean;
+  slots: Array<{
+    id: number;
+    minMentors: number;
+    maxMentors: number;
+  }>;
+}
+
+export const useMatcherConfig = (courseId: number): UseQueryResult<MatcherConfigResponse, ServerError> => {
+  const queryResult = useQuery<MatcherConfigResponse, Error>(["matcher", courseId, "config"], async () => {
+    const response = await fetchNormalized(`/matcher/${courseId}/configure`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch matcher config for course ${courseId}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface MatcherAssignmentResponse {
+  assignment: Assignment[];
+}
+
+export const useMatcherAssignment = (courseId: number): UseQueryResult<MatcherAssignmentResponse, ServerError> => {
+  const queryResult = useQuery<MatcherAssignmentResponse, Error>(["matcher", courseId, "assignment"], async () => {
+    const response = await fetchNormalized(`/matcher/${courseId}/assignment`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch matcher assignment for course ${courseId}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+interface MatcherMentorsResponse {
+  mentors: Mentor[];
+}
+
+export const useMatcherMentors = (courseId: number): UseQueryResult<MatcherMentorsResponse, ServerError> => {
+  const queryResult = useQuery<MatcherMentorsResponse, Error>(["matcher", courseId, "mentors"], async () => {
+    const response = await fetchNormalized(`/matcher/${courseId}/mentors`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch matcher mentors for course ${courseId}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/* ===== Mutations ===== */
+
+type MatcherPreferenceMutationRequest = Array<{
+  id: number;
+  preference: number;
+}>;
+
+export const useMatcherPreferenceMutation = (
+  courseId: number
+): UseMutationResult<boolean, ServerError, MatcherPreferenceMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<boolean, Error, MatcherPreferenceMutationRequest>(
+    async (body: MatcherPreferenceMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/preferences`, HTTP_METHODS.POST, body);
+      if (!response.ok && response.status === 500) {
+        throw new ServerError(`Failed to update matcher preferences for course ${courseId}`);
+      }
+      return response.ok;
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "preferences"]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+interface MatcherSlotsMutationRequest {
+  slots: Array<{
+    id?: number;
+    times: Array<{
+      day: string;
+      startTime: string;
+      endTime: string;
+    }>;
+  }>;
+}
+
+export const useMatcherSlotsMutation = (
+  courseId: number
+): UseMutationResult<void, ServerError, MatcherSlotsMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, MatcherSlotsMutationRequest>(
+    async (body: MatcherSlotsMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/slots`, HTTP_METHODS.POST, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to create matcher slots for course ${courseId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "slots"]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+interface MatcherConfigMutationRequest {
+  open?: boolean;
+  run?: boolean;
+  slots?: Array<{
+    id?: number;
+    minMentors?: number;
+    maxMentors?: number;
+  }>;
+}
+
+interface MatcherConfigMutationResponse {
+  error?: string;
+}
+
+/**
+ * Hook to modify matcher configuration.
+ *
+ * Used to open/close the matcher, run the matcher, and modify the configuration of the matcher algorithm.
+ *
+ * @param courseId The course ID to modify the matcher configuration for.
+ * @param invalidateAssignments Whether to invalidate the matcher assignment query when the mutation is successful.
+ *                            Used when running the matcher to update the stage.
+ */
+export const useMatcherConfigMutation = (
+  courseId: number,
+  invalidateAssignments = false
+): UseMutationResult<void, MatcherConfigMutationResponse, MatcherConfigMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, MatcherConfigMutationResponse, MatcherConfigMutationRequest>(
+    async (body: MatcherConfigMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/configure`, HTTP_METHODS.POST, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw await response.json();
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "config"]);
+        if (invalidateAssignments) {
+          queryClient.invalidateQueries(["matcher", courseId, "assignment"]);
+        }
+      }
+    }
+  );
+
+  // handle error in mutation
+  return mutationResult;
+};
+
+interface MatcherAssignmentMutationRequest {
+  assignment: Assignment[];
+}
+
+export const useMatcherAssignmentMutation = (
+  courseId: number
+): UseMutationResult<void, ServerError, MatcherAssignmentMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, MatcherAssignmentMutationRequest>(
+    async (body: MatcherAssignmentMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/assignment`, HTTP_METHODS.PUT, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to update matcher assignment for course ${courseId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "assignment"]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+interface MatcherMentorsMutationRequest {
+  mentors: string[];
+}
+
+interface MatcherMentorsMutationResponse {
+  skipped: string[];
+}
+
+export const useMatcherAddMentorsMutation = (
+  courseId: number
+): UseMutationResult<MatcherMentorsMutationResponse, ServerError, MatcherMentorsMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<MatcherMentorsMutationResponse, Error, MatcherMentorsMutationRequest>(
+    async (body: MatcherMentorsMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/mentors`, HTTP_METHODS.POST, body);
+      if (response.ok) {
+        return response.json();
+      } else {
+        throw new ServerError(`Failed to update matcher mentors for course ${courseId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "mentors"]);
+        // possibly added the current user, so reload profiles too
+        queryClient.invalidateQueries(["profiles"]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+export const useMatcherRemoveMentorsMutation = (
+  courseId: number
+): UseMutationResult<void, ServerError, MatcherMentorsMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, MatcherMentorsMutationRequest>(
+    async (body: MatcherMentorsMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/mentors`, HTTP_METHODS.DELETE, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to update matcher mentors for course ${courseId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId, "mentors"]);
+        // possibly removed the current user, so reload profiles too
+        queryClient.invalidateQueries(["profiles"]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+interface MatcherCreateSectionsMutationRequest {
+  assignment: Assignment[];
+}
+
+interface MatcherCreateSectionsMutationResponse {
+  error?: string;
+}
+
+export const useMatcherCreateSectionsMutation = (
+  courseId: number
+): UseMutationResult<void, MatcherCreateSectionsMutationResponse, MatcherCreateSectionsMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, MatcherCreateSectionsMutationResponse, MatcherCreateSectionsMutationRequest>(
+    async (body: MatcherCreateSectionsMutationRequest) => {
+      const response = await fetchWithMethod(`/matcher/${courseId}/create`, HTTP_METHODS.POST, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw await response.json();
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["matcher", courseId]);
+        queryClient.invalidateQueries(["matcher", "active"]);
+        queryClient.invalidateQueries(["profiles"]);
+      }
+    }
+  );
+
+  // handle error in component
+  return mutationResult;
+};

--- a/csm_web/frontend/src/utils/queries/matcher.tsx
+++ b/csm_web/frontend/src/utils/queries/matcher.tsx
@@ -13,19 +13,26 @@ import {
 import { Assignment, Slot } from "../../components/enrollment_automation/EnrollmentAutomationTypes";
 import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
 import { Mentor } from "../types";
-import { handleError, ServerError } from "./helpers";
+import { handleError, handlePermissionsError, handleRetry, PermissionError, ServerError } from "./helpers";
 
 /* ==== Queries ===== */
 
 export const useMatcherActiveCourses = (): UseQueryResult<number[], ServerError> => {
-  const queryResult = useQuery<number[], Error>(["matcher", "active"], async () => {
-    const response = await fetchNormalized("/matcher/active");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch active matcher courses");
+  const queryResult = useQuery<number[], Error>(
+    ["matcher", "active"],
+    async () => {
+      const response = await fetchNormalized("/matcher/active");
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError("Failed to fetch active matcher courses");
+      }
+    },
+    {
+      retry: handleRetry
     }
-  });
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -52,14 +59,21 @@ interface MatcherSlotsResponseTime {
  * Hook to fetch the matcher slots for a given course.
  */
 export const useMatcherSlots = (courseId: number): UseQueryResult<MatcherSlotsResponse, ServerError> => {
-  const queryResult = useQuery<MatcherSlotsResponse, Error>(["matcher", courseId, "slots"], async () => {
-    const response = await fetchNormalized(`/matcher/${courseId}/slots`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError(`Failed to fetch matcher slots for course ${courseId}`);
+  const queryResult = useQuery<MatcherSlotsResponse, Error>(
+    ["matcher", courseId, "slots"],
+    async () => {
+      const response = await fetchNormalized(`/matcher/${courseId}/slots`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError(`Failed to fetch matcher slots for course ${courseId}`);
+      }
+    },
+    {
+      retry: handleRetry
     }
-  });
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -70,14 +84,24 @@ interface MatcherPreferencesResponse {
 }
 
 export const useMatcherPreferences = (courseId: number): UseQueryResult<MatcherPreferencesResponse, ServerError> => {
-  const queryResult = useQuery<MatcherPreferencesResponse, Error>(["matcher", courseId, "preferences"], async () => {
-    const response = await fetchNormalized(`/matcher/${courseId}/preferences`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch matcher preferences");
+  const queryResult = useQuery<MatcherPreferencesResponse, Error>(
+    ["matcher", courseId, "preferences"],
+    async () => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
+      const response = await fetchNormalized(`/matcher/${courseId}/preferences`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError("Failed to fetch matcher preferences");
+      }
+    },
+    {
+      retry: handleRetry
     }
-  });
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -93,14 +117,22 @@ interface MatcherConfigResponse {
 }
 
 export const useMatcherConfig = (courseId: number): UseQueryResult<MatcherConfigResponse, ServerError> => {
-  const queryResult = useQuery<MatcherConfigResponse, Error>(["matcher", courseId, "config"], async () => {
-    const response = await fetchNormalized(`/matcher/${courseId}/configure`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError(`Failed to fetch matcher config for course ${courseId}`);
-    }
-  });
+  const queryResult = useQuery<MatcherConfigResponse, Error>(
+    ["matcher", courseId, "config"],
+    async () => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
+      const response = await fetchNormalized(`/matcher/${courseId}/configure`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError(`Failed to fetch matcher config for course ${courseId}`);
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -111,14 +143,22 @@ interface MatcherAssignmentResponse {
 }
 
 export const useMatcherAssignment = (courseId: number): UseQueryResult<MatcherAssignmentResponse, ServerError> => {
-  const queryResult = useQuery<MatcherAssignmentResponse, Error>(["matcher", courseId, "assignment"], async () => {
-    const response = await fetchNormalized(`/matcher/${courseId}/assignment`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError(`Failed to fetch matcher assignment for course ${courseId}`);
-    }
-  });
+  const queryResult = useQuery<MatcherAssignmentResponse, Error>(
+    ["matcher", courseId, "assignment"],
+    async () => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
+      const response = await fetchNormalized(`/matcher/${courseId}/assignment`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError(`Failed to fetch matcher assignment for course ${courseId}`);
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -129,14 +169,22 @@ interface MatcherMentorsResponse {
 }
 
 export const useMatcherMentors = (courseId: number): UseQueryResult<MatcherMentorsResponse, ServerError> => {
-  const queryResult = useQuery<MatcherMentorsResponse, Error>(["matcher", courseId, "mentors"], async () => {
-    const response = await fetchNormalized(`/matcher/${courseId}/mentors`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError(`Failed to fetch matcher mentors for course ${courseId}`);
-    }
-  });
+  const queryResult = useQuery<MatcherMentorsResponse, Error>(
+    ["matcher", courseId, "mentors"],
+    async () => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
+      const response = await fetchNormalized(`/matcher/${courseId}/mentors`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError(`Failed to fetch matcher mentors for course ${courseId}`);
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -155,6 +203,9 @@ export const useMatcherPreferenceMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<boolean, Error, MatcherPreferenceMutationRequest>(
     async (body: MatcherPreferenceMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/preferences`, HTTP_METHODS.POST, body);
       if (!response.ok && response.status === 500) {
         throw new ServerError(`Failed to update matcher preferences for course ${courseId}`);
@@ -189,17 +240,22 @@ export const useMatcherSlotsMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, MatcherSlotsMutationRequest>(
     async (body: MatcherSlotsMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/slots`, HTTP_METHODS.POST, body);
       if (response.ok) {
         return;
       } else {
+        handlePermissionsError(response.status);
         throw new ServerError(`Failed to create matcher slots for course ${courseId}`);
       }
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["matcher", courseId, "slots"]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -237,6 +293,9 @@ export const useMatcherConfigMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, MatcherConfigMutationResponse, MatcherConfigMutationRequest>(
     async (body: MatcherConfigMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/configure`, HTTP_METHODS.POST, body);
       if (response.ok) {
         return;
@@ -268,17 +327,22 @@ export const useMatcherAssignmentMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, MatcherAssignmentMutationRequest>(
     async (body: MatcherAssignmentMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/assignment`, HTTP_METHODS.PUT, body);
       if (response.ok) {
         return;
       } else {
+        handlePermissionsError(response.status);
         throw new ServerError(`Failed to update matcher assignment for course ${courseId}`);
       }
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["matcher", courseId, "assignment"]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -300,10 +364,14 @@ export const useMatcherAddMentorsMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<MatcherMentorsMutationResponse, Error, MatcherMentorsMutationRequest>(
     async (body: MatcherMentorsMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/mentors`, HTTP_METHODS.POST, body);
       if (response.ok) {
         return response.json();
       } else {
+        handlePermissionsError(response.status);
         throw new ServerError(`Failed to update matcher mentors for course ${courseId}`);
       }
     },
@@ -312,7 +380,8 @@ export const useMatcherAddMentorsMutation = (
         queryClient.invalidateQueries(["matcher", courseId, "mentors"]);
         // possibly added the current user, so reload profiles too
         queryClient.invalidateQueries(["profiles"]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -326,10 +395,14 @@ export const useMatcherRemoveMentorsMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, MatcherMentorsMutationRequest>(
     async (body: MatcherMentorsMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/mentors`, HTTP_METHODS.DELETE, body);
       if (response.ok) {
         return;
       } else {
+        handlePermissionsError(response.status);
         throw new ServerError(`Failed to update matcher mentors for course ${courseId}`);
       }
     },
@@ -338,7 +411,8 @@ export const useMatcherRemoveMentorsMutation = (
         queryClient.invalidateQueries(["matcher", courseId, "mentors"]);
         // possibly removed the current user, so reload profiles too
         queryClient.invalidateQueries(["profiles"]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -360,6 +434,9 @@ export const useMatcherCreateSectionsMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, MatcherCreateSectionsMutationResponse, MatcherCreateSectionsMutationRequest>(
     async (body: MatcherCreateSectionsMutationRequest) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/matcher/${courseId}/create`, HTTP_METHODS.POST, body);
       if (response.ok) {
         return;

--- a/csm_web/frontend/src/utils/queries/resources.tsx
+++ b/csm_web/frontend/src/utils/queries/resources.tsx
@@ -5,19 +5,27 @@
 import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from "@tanstack/react-query";
 import { Resource } from "../../components/resource_aggregation/ResourceTypes";
 import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
-import { handleError, ServerError } from "./helpers";
+import { handleError, handlePermissionsError, handleRetry, PermissionError, ServerError } from "./helpers";
 
 /* ===== Queries ===== */
 
 export const useResources = (courseId: number): UseQueryResult<Resource[], ServerError> => {
-  const queryResult = useQuery<Resource[], Error>(["resources", courseId], async () => {
-    const response = await fetchNormalized(`/resources/${courseId}/resources`);
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError(`Failed to fetch resources for course ${courseId}`);
-    }
-  });
+  const queryResult = useQuery<Resource[], Error>(
+    ["resources", courseId],
+    async () => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
+      const response = await fetchNormalized(`/resources/${courseId}/resources`);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        handlePermissionsError(response.status);
+        throw new ServerError(`Failed to fetch resources for course ${courseId}`);
+      }
+    },
+    { retry: handleRetry }
+  );
 
   handleError(queryResult);
   return queryResult;
@@ -29,6 +37,9 @@ export const useCreateResourceMutation = (courseId: number): UseMutationResult<v
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, FormData>(
     async (formdata: FormData) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.POST, formdata, true);
       if (response.ok) {
         return await response.json();
@@ -37,6 +48,7 @@ export const useCreateResourceMutation = (courseId: number): UseMutationResult<v
           // invalid data; log the error and continue
           console.error(await response.json());
         } else {
+          handlePermissionsError(response.status);
           throw new ServerError(`Failed to create resource for course ${courseId}`);
         }
       }
@@ -44,7 +56,8 @@ export const useCreateResourceMutation = (courseId: number): UseMutationResult<v
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["resources", courseId]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -56,6 +69,9 @@ export const useUpdateResourceMutation = (courseId: number): UseMutationResult<v
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, FormData>(
     async (formdata: FormData) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.PUT, formdata, true);
       if (response.ok) {
         return await response.json();
@@ -64,6 +80,7 @@ export const useUpdateResourceMutation = (courseId: number): UseMutationResult<v
           // invalid data; log the error and continue
           console.error(await response.json());
         } else {
+          handlePermissionsError(response.status);
           throw new ServerError(`Failed to update resource for course ${courseId}`);
         }
       }
@@ -71,7 +88,8 @@ export const useUpdateResourceMutation = (courseId: number): UseMutationResult<v
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["resources", courseId]);
-      }
+      },
+      retry: handleRetry
     }
   );
 
@@ -89,17 +107,22 @@ export const useDeleteResourceMutation = (
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, DeleteResourceMutationRequestBody>(
     async (body: DeleteResourceMutationRequestBody) => {
+      if (isNaN(courseId)) {
+        throw new PermissionError("Invalid course id");
+      }
       const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.DELETE, body);
       if (response.ok) {
         return await response.json();
       } else {
+        handlePermissionsError(response.status);
         throw new ServerError(`Failed to delete resource ${body.id} for course ${courseId}`);
       }
     },
     {
       onSuccess: () => {
         queryClient.invalidateQueries(["resources", courseId]);
-      }
+      },
+      retry: handleRetry
     }
   );
 

--- a/csm_web/frontend/src/utils/queries/resources.tsx
+++ b/csm_web/frontend/src/utils/queries/resources.tsx
@@ -1,0 +1,108 @@
+/**
+ * Query hooks regarding resources.
+ */
+
+import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from "@tanstack/react-query";
+import { Resource } from "../../components/resource_aggregation/ResourceTypes";
+import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
+import { handleError, ServerError } from "./helpers";
+
+/* ===== Queries ===== */
+
+export const useResources = (courseId: number): UseQueryResult<Resource[], ServerError> => {
+  const queryResult = useQuery<Resource[], Error>(["resources", courseId], async () => {
+    const response = await fetchNormalized(`/resources/${courseId}/resources`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch resources for course ${courseId}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/* ===== Mutations ===== */
+
+export const useCreateResourceMutation = (courseId: number): UseMutationResult<void, ServerError, FormData> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, FormData>(
+    async (formdata: FormData) => {
+      const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.POST, formdata, true);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        if (response.status === 400) {
+          // invalid data; log the error and continue
+          console.error(await response.json());
+        } else {
+          throw new ServerError(`Failed to create resource for course ${courseId}`);
+        }
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["resources", courseId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+export const useUpdateResourceMutation = (courseId: number): UseMutationResult<void, ServerError, FormData> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, FormData>(
+    async (formdata: FormData) => {
+      const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.PUT, formdata, true);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        if (response.status === 400) {
+          // invalid data; log the error and continue
+          console.error(await response.json());
+        } else {
+          throw new ServerError(`Failed to update resource for course ${courseId}`);
+        }
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["resources", courseId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+interface DeleteResourceMutationRequestBody {
+  id: number;
+}
+
+export const useDeleteResourceMutation = (
+  courseId: number
+): UseMutationResult<void, ServerError, DeleteResourceMutationRequestBody> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, DeleteResourceMutationRequestBody>(
+    async (body: DeleteResourceMutationRequestBody) => {
+      const response = await fetchWithMethod(`/resources/${courseId}/resources`, HTTP_METHODS.DELETE, body);
+      if (response.ok) {
+        return await response.json();
+      } else {
+        throw new ServerError(`Failed to delete resource ${body.id} for course ${courseId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(["resources", courseId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};

--- a/csm_web/frontend/src/utils/queries/section.tsx
+++ b/csm_web/frontend/src/utils/queries/section.tsx
@@ -1,92 +1,13 @@
 /**
- * File containing all the query functions for the frontend.
- * All query hooks follow the same procedure:
- * - Fetch the data from the backend API
- * - If an error occurs, throw the error with some additional details
- * - Otherwise, return the QueryResult object
- *
- * There is no need for error handling in the frontend;
- * the error boundary in App.tsx will catch any errors and display a friendly error page.
+ * Query hooks regarding sections.
  */
 
-import { useQuery, useMutation, useQueryClient, UseQueryResult, UseMutationResult } from "react-query";
+import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from "@tanstack/react-query";
+import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
+import { RawAttendance, Section, Student } from "../types";
+import { handleError, ServerError } from "./helpers";
 
-import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "./api";
-import { RawAttendance, Course, Profile, RawUserInfo, Section, Student } from "./types";
-
-/**
- * Derived class of Error for internal server errors.
- */
-export class ServerError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "ServerError";
-  }
-}
-
-/**
- * Handle errors from the backend API, if any occur.
- * If no error, nothing happens.
- */
-const handleError = (result: UseQueryResult<any, ServerError> | UseMutationResult<any, ServerError, any>): void => {
-  if (result.isError) {
-    const failures = result.failureCount;
-    throw new ServerError(`${result.error.message} (${failures} failures)`);
-  }
-};
-
-/* === Queries === */
-
-/**
- * Hook to get the user's profile list.
- */
-export const useProfiles = () => {
-  const queryResult = useQuery<Profile[], ServerError>("profiles", async () => {
-    const response = await fetchNormalized("/profiles");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch profiles");
-    }
-  });
-
-  handleError(queryResult);
-  return queryResult;
-};
-
-/**
- * Hook to get all courses.
- */
-export const useCourses = (): UseQueryResult<Course[], ServerError> => {
-  const queryResult = useQuery<Course[], Error>("courses", async () => {
-    const response = await fetchNormalized("/courses");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch courses");
-    }
-  });
-
-  handleError(queryResult);
-  return queryResult;
-};
-
-/**
- * Hook to get the user's info.
- */
-export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
-  const queryResult = useQuery<RawUserInfo, Error>("userinfo", async () => {
-    const response = await fetchNormalized("/userinfo");
-    if (response.ok) {
-      return await response.json();
-    } else {
-      throw new ServerError("Failed to fetch user info");
-    }
-  });
-
-  handleError(queryResult);
-  return queryResult;
-};
+/* ===== Queries ===== */
 
 /**
  * Hook to get a section with a given id.
@@ -143,7 +64,7 @@ export const useSectionAttendances = (id: number): UseQueryResult<RawAttendance[
   return queryResult;
 };
 
-/* === Mutations === */
+/* ===== Mutations ===== */
 
 export interface StudentDropMutationBody {
   banned: boolean;

--- a/csm_web/frontend/src/utils/queries/sections.tsx
+++ b/csm_web/frontend/src/utils/queries/sections.tsx
@@ -4,7 +4,7 @@
 
 import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from "@tanstack/react-query";
 import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "../api";
-import { RawAttendance, Section, Spacetime, Student } from "../types";
+import { Attendance, RawAttendance, Section, Spacetime, Student } from "../types";
 import { handleError, ServerError } from "./helpers";
 
 /* ===== Queries ===== */
@@ -28,6 +28,8 @@ export const useSection = (id: number): UseQueryResult<Section, ServerError> => 
 
 /**
  * Hook to get the students enrolled in a section.
+ *
+ * List of students is sorted by name.
  */
 export const useSectionStudents = (id: number): UseQueryResult<Student[], ServerError> => {
   const queryResult = useQuery<Student[], Error>(["sections", id, "students"], async () => {
@@ -64,6 +66,20 @@ export const useSectionAttendances = (id: number): UseQueryResult<RawAttendance[
   return queryResult;
 };
 
+export const useStudentAttendances = (studentId: number): UseQueryResult<Attendance[], ServerError> => {
+  const queryResult = useQuery<Attendance[], Error>(["students", studentId, "attendance"], async () => {
+    const response = await fetchNormalized(`/students/${studentId}/attendances`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch student ${studentId} attendances`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
 /* ===== Mutations ===== */
 
 export interface StudentDropMutationBody {
@@ -71,12 +87,13 @@ export interface StudentDropMutationBody {
 }
 
 /**
- * Hook to drop a student from their section
+ * Hook to drop a student from their section.
+ *
+ * Invalidates all queries associated with the section.
  */
-export const useStudentDropMutation = (
+export const useDropStudentMutation = (
   studentId: number,
-  sectionId: number,
-  droppedSelf = false
+  sectionId: number
 ): UseMutationResult<void, ServerError, StudentDropMutationBody> => {
   const queryClient = useQueryClient();
   const mutationResult = useMutation<void, Error, StudentDropMutationBody>(
@@ -92,11 +109,6 @@ export const useStudentDropMutation = (
       onSuccess: () => {
         // invalidate all queries for the section
         queryClient.invalidateQueries(["sections", sectionId]);
-
-        if (droppedSelf) {
-          // invalidate profiles query
-          queryClient.invalidateQueries(["profiles"]);
-        }
       }
     }
   );
@@ -105,20 +117,50 @@ export const useStudentDropMutation = (
   return mutationResult;
 };
 
-export interface EnrollStudentMutationResponse {
+/**
+ * Hook to drop the current user from their section.
+ *
+ * Invalidates the current user profile query.
+ */
+export const useDropUserMutation = (studentId: number) => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, void>(
+    async () => {
+      const response = await fetchWithMethod(`students/${studentId}/drop`, HTTP_METHODS.PATCH);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to drop student ${studentId} from section`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate profiles query
+        queryClient.invalidateQueries(["profiles"]);
+        // no need to invalidate section queries
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+export interface EnrollUserMutationResponse {
   detail: string;
 }
 
 /**
- * Enroll a student (the user) into a given section.
+ * Enroll the current user into a given section.
  *
- * If the mutation fails,
+ * On success, returns nothing; on failure, returns the response body.
+ *
+ * Invalidates all queries associated with the section,
+ * along with the current user profile query.
  */
-export const useEnrollStudentMutation = (
-  sectionId: number
-): UseMutationResult<void, EnrollStudentMutationResponse, void> => {
+export const useEnrollUserMutation = (sectionId: number): UseMutationResult<void, EnrollUserMutationResponse, void> => {
   const queryClient = useQueryClient();
-  const mutationResult = useMutation<void, EnrollStudentMutationResponse, void>(
+  const mutationResult = useMutation<void, EnrollUserMutationResponse, void>(
     async () => {
       const response = await fetchWithMethod(`sections/${sectionId}/students`, HTTP_METHODS.PUT);
       if (response.ok) {
@@ -133,6 +175,61 @@ export const useEnrollStudentMutation = (
         queryClient.invalidateQueries(["sections", sectionId]);
         // invalidate profiles query for the user
         queryClient.invalidateQueries(["profiles"]);
+      }
+    }
+  );
+
+  // handle error in component
+  return mutationResult;
+};
+
+interface EnrollStudentMutationRequest {
+  emails: Array<{ [email: string]: string }>;
+  actions: {
+    [action: string]: string;
+  };
+}
+
+interface EnrollStudentMutationResponse {
+  status: number;
+  json: {
+    errors?: {
+      critical?: string;
+      capacity?: string;
+    };
+    progress?: Array<{
+      email: string;
+      status: string;
+      detail?: any;
+    }>;
+  };
+}
+
+/**
+ * Enroll a list of students into a given section.
+ *
+ * On success, returns nothing; on failure, returns the response body.
+ * Failure response body contains the JSON response along with the response status.
+ *
+ * Invalidates all queries associated with the section.
+ */
+export const useEnrollStudentMutation = (
+  sectionId: number
+): UseMutationResult<void, EnrollStudentMutationResponse, EnrollStudentMutationRequest> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, EnrollStudentMutationResponse, EnrollStudentMutationRequest>(
+    async (body: EnrollStudentMutationRequest) => {
+      const response = await fetchWithMethod(`sections/${sectionId}/students`, HTTP_METHODS.PUT, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw { status: response.status, json: await response.json() };
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId]);
       }
     }
   );

--- a/csm_web/frontend/src/utils/queries/sections.tsx
+++ b/csm_web/frontend/src/utils/queries/sections.tsx
@@ -297,3 +297,36 @@ export const useSectionCreateMutation = (): UseMutationResult<Section, ServerErr
   handleError(mutationResult);
   return mutationResult;
 };
+
+export interface SectionUpdateMutationBody {
+  capacity: number;
+  description: string;
+}
+
+/**
+ * Hook to modify a section
+ */
+export const useSectionUpdateMutation = (
+  sectionId: number
+): UseMutationResult<void, ServerError, SectionUpdateMutationBody> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, SectionUpdateMutationBody>(
+    async (body: SectionUpdateMutationBody) => {
+      const response = await fetchWithMethod(`/sections/${sectionId}/`, HTTP_METHODS.PATCH, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to create section`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};

--- a/csm_web/frontend/src/utils/queries/sections.tsx
+++ b/csm_web/frontend/src/utils/queries/sections.tsx
@@ -82,6 +82,39 @@ export const useStudentAttendances = (studentId: number): UseQueryResult<Attenda
 
 /* ===== Mutations ===== */
 
+export interface UpdateStudentAttendanceBody {
+  id: number;
+  presence: string;
+}
+export interface UpdateStudentAttendancesMutationParams {
+  studentId: number;
+  body: UpdateStudentAttendanceBody;
+}
+
+export const useUpdateStudentAttendancesMutation = (
+  sectionId: number
+): UseMutationResult<void, ServerError, UpdateStudentAttendancesMutationParams> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, UpdateStudentAttendancesMutationParams>(
+    async ({ studentId, body }: UpdateStudentAttendancesMutationParams) => {
+      const response = await fetchWithMethod(`students/${studentId}/attendances/`, HTTP_METHODS.PUT, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to save attendance ${body.id} for student ${studentId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        //invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId, "attendance"]);
+      }
+    }
+  );
+  handleError(mutationResult);
+  return mutationResult;
+};
+
 export interface StudentDropMutationBody {
   banned: boolean;
 }

--- a/csm_web/frontend/src/utils/queries/spacetime.tsx
+++ b/csm_web/frontend/src/utils/queries/spacetime.tsx
@@ -1,0 +1,79 @@
+/**
+ * Query hooks regarding spacetimes.
+ */
+
+import { useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import { fetchWithMethod, HTTP_METHODS } from "../api";
+import { handleError, ServerError } from "./helpers";
+
+/* ===== Mutations ===== */
+
+export interface SpacetimeModifyMutationBody {
+  day_of_week: string;
+  location: string | undefined;
+  start_time: string;
+}
+
+/**
+ * Hook to modify a section's spacetime.
+ */
+export const useSpacetimeModifyMutation = (
+  sectionId: number,
+  spacetimeId: number
+): UseMutationResult<void, ServerError, SpacetimeModifyMutationBody> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, SpacetimeModifyMutationBody>(
+    async (body: SpacetimeModifyMutationBody) => {
+      const response = await fetchWithMethod(`/spacetimes/${spacetimeId}/modify`, HTTP_METHODS.PUT, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to update spacetime ${spacetimeId} for section ${sectionId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};
+
+export interface SpacetimeOverrideMutationBody {
+  location: string | undefined;
+  start_time: string;
+  date: string;
+}
+
+/**
+ * Hook to override a section's spacetime.
+ */
+export const useSpacetimeOverrideMutation = (
+  sectionId: number,
+  spacetimeId: number
+): UseMutationResult<void, ServerError, SpacetimeOverrideMutationBody> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, SpacetimeOverrideMutationBody>(
+    async (body: SpacetimeOverrideMutationBody) => {
+      const response = await fetchWithMethod(`/spacetimes/${spacetimeId}/override`, HTTP_METHODS.PUT, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to override spacetime ${spacetimeId} for section ${sectionId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
+};

--- a/csm_web/frontend/src/utils/query.tsx
+++ b/csm_web/frontend/src/utils/query.tsx
@@ -9,10 +9,10 @@
  * the error boundary in App.tsx will catch any errors and display a friendly error page.
  */
 
-import { useQuery, UseQueryResult } from "react-query";
+import { useQuery, useMutation, useQueryClient, UseQueryResult, UseMutationResult } from "react-query";
 
-import { fetchNormalized } from "./api";
-import { Course, Profile, RawUserInfo } from "./types";
+import { fetchNormalized, fetchWithMethod, HTTP_METHODS } from "./api";
+import { RawAttendance, Course, Profile, RawUserInfo, Section, Student } from "./types";
 
 /**
  * Derived class of Error for internal server errors.
@@ -28,12 +28,14 @@ export class ServerError extends Error {
  * Handle errors from the backend API, if any occur.
  * If no error, nothing happens.
  */
-const handleError = (queryResult: UseQueryResult<any, ServerError>): void => {
-  if (queryResult.isError) {
-    const failures = queryResult.failureCount;
-    throw new ServerError(`${queryResult.error.message} (${failures} failures)`);
+const handleError = (result: UseQueryResult<any, ServerError> | UseMutationResult<any, ServerError, any>): void => {
+  if (result.isError) {
+    const failures = result.failureCount;
+    throw new ServerError(`${result.error.message} (${failures} failures)`);
   }
 };
+
+/* === Queries === */
 
 /**
  * Hook to get the user's profile list.
@@ -52,6 +54,9 @@ export const useProfiles = () => {
   return queryResult;
 };
 
+/**
+ * Hook to get all courses.
+ */
 export const useCourses = (): UseQueryResult<Course[], ServerError> => {
   const queryResult = useQuery<Course[], Error>("courses", async () => {
     const response = await fetchNormalized("/courses");
@@ -66,6 +71,9 @@ export const useCourses = (): UseQueryResult<Course[], ServerError> => {
   return queryResult;
 };
 
+/**
+ * Hook to get the user's info.
+ */
 export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
   const queryResult = useQuery<RawUserInfo, Error>("userinfo", async () => {
     const response = await fetchNormalized("/userinfo");
@@ -78,4 +86,94 @@ export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
 
   handleError(queryResult);
   return queryResult;
+};
+
+/**
+ * Hook to get a section with a given id.
+ */
+export const useSection = (id: number): UseQueryResult<Section, ServerError> => {
+  const queryResult = useQuery<Section, Error>(["sections", id], async () => {
+    const response = await fetchNormalized(`/sections/${id}`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch section ${id}`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/**
+ * Hook to get the students enrolled in a section.
+ */
+export const useSectionStudents = (id: number): UseQueryResult<Student[], ServerError> => {
+  const queryResult = useQuery<Student[], Error>(["sections", id, "students"], async () => {
+    const response = await fetchNormalized(`/sections/${id}/students`);
+    if (response.ok) {
+      const students = await response.json();
+      // sort students by name before returning
+      return students.sort((stu1: Student, stu2: Student) =>
+        stu1.name.toLowerCase().localeCompare(stu2.name.toLowerCase())
+      );
+    } else {
+      throw new ServerError(`Failed to fetch section ${id} students`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/**
+ * Hook to get the attendances for a section.
+ */
+export const useSectionAttendances = (id: number): UseQueryResult<RawAttendance[], ServerError> => {
+  const queryResult = useQuery<RawAttendance[], Error>(["sections", id, "attendance"], async () => {
+    const response = await fetchNormalized(`/sections/${id}/attendance`);
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError(`Failed to fetch section ${id} attendances`);
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+/* === Mutations === */
+
+export interface StudentDropMutationBody {
+  banned: boolean;
+}
+
+/**
+ * Hook to drop a student from their section
+ */
+export const useStudentDropMutation = (
+  studentId: number,
+  sectionId: number
+): UseMutationResult<void, ServerError, StudentDropMutationBody> => {
+  const queryClient = useQueryClient();
+  const mutationResult = useMutation<void, Error, StudentDropMutationBody>(
+    async (body: StudentDropMutationBody) => {
+      const response = await fetchWithMethod(`students/${studentId}/drop`, HTTP_METHODS.PATCH, body);
+      if (response.ok) {
+        return;
+      } else {
+        throw new ServerError(`Failed to drop student ${studentId} from section ${sectionId}`);
+      }
+    },
+    {
+      onSuccess: () => {
+        // invalidate all queries for the section
+        queryClient.invalidateQueries(["sections", sectionId]);
+      }
+    }
+  );
+
+  handleError(mutationResult);
+  return mutationResult;
 };

--- a/csm_web/frontend/src/utils/query.tsx
+++ b/csm_web/frontend/src/utils/query.tsx
@@ -1,0 +1,81 @@
+/**
+ * File containing all the query functions for the frontend.
+ * All query hooks follow the same procedure:
+ * - Fetch the data from the backend API
+ * - If an error occurs, throw the error with some additional details
+ * - Otherwise, return the QueryResult object
+ *
+ * There is no need for error handling in the frontend;
+ * the error boundary in App.tsx will catch any errors and display a friendly error page.
+ */
+
+import { useQuery, UseQueryResult } from "react-query";
+
+import { fetchNormalized } from "./api";
+import { Course, Profile, RawUserInfo } from "./types";
+
+/**
+ * Derived class of Error for internal server errors.
+ */
+export class ServerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ServerError";
+  }
+}
+
+/**
+ * Handle errors from the backend API, if any occur.
+ * If no error, nothing happens.
+ */
+const handleError = (queryResult: UseQueryResult<any, ServerError>): void => {
+  if (queryResult.isError) {
+    const failures = queryResult.failureCount;
+    throw new ServerError(`${queryResult.error.message} (${failures} failures)`);
+  }
+};
+
+/**
+ * Hook to get the user's profile list.
+ */
+export const useProfiles = () => {
+  const queryResult = useQuery<Profile[], ServerError>("profiles", async () => {
+    const response = await fetchNormalized("/profiles");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch profiles");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+export const useCourses = (): UseQueryResult<Course[], ServerError> => {
+  const queryResult = useQuery<Course[], Error>("courses", async () => {
+    const response = await fetchNormalized("/courses");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch courses");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};
+
+export const useUserInfo = (): UseQueryResult<RawUserInfo, ServerError> => {
+  const queryResult = useQuery<RawUserInfo, Error>("userinfo", async () => {
+    const response = await fetchNormalized("/userinfo");
+    if (response.ok) {
+      return await response.json();
+    } else {
+      throw new ServerError("Failed to fetch user info");
+    }
+  });
+
+  handleError(queryResult);
+  return queryResult;
+};

--- a/csm_web/frontend/src/utils/types.tsx
+++ b/csm_web/frontend/src/utils/types.tsx
@@ -78,3 +78,17 @@ export interface Attendance {
   student: Student;
   presence: string;
 }
+
+export interface RawAttendance {
+  id: number;
+  date: string;
+  section: Section;
+  attendances: Array<{
+    id: number;
+    date: string;
+    presence: string;
+    studentName: string;
+    studentId: number;
+    studentEmail: string;
+  }>;
+}

--- a/csm_web/frontend/src/utils/types.tsx
+++ b/csm_web/frontend/src/utils/types.tsx
@@ -23,6 +23,21 @@ export interface Profile {
   sectionSpacetimes: Array<Spacetime>;
 }
 
+export interface UserInfo {
+  id: number;
+  firstName: string;
+  lastName: string;
+  email: string;
+  priorityEnrollment?: Date;
+}
+
+/**
+ * Raw type from the query response.
+ */
+export type RawUserInfo = Omit<UserInfo, "priorityEnrollment"> & {
+  priorityEnrollment?: string;
+};
+
 export interface Section {
   id: number;
   spacetimes: Spacetime[];

--- a/csm_web/frontend/src/utils/user.tsx
+++ b/csm_web/frontend/src/utils/user.tsx
@@ -1,4 +1,4 @@
-import { fetchJSON } from "./api";
+import { Profile } from "./types";
 
 export interface Roles {
   STUDENT: Set<number>;
@@ -24,12 +24,10 @@ export function emptyRoles(): Roles {
  *
  * @returns all user roles split by role type
  */
-export function getRoles(): Promise<Roles> {
-  return fetchJSON("/profiles").then(profiles => {
-    const roles = emptyRoles();
-    profiles.map(course => {
-      roles[course.role].add(course.courseId);
-    });
-    return roles;
+export function getRoles(profiles: Profile[]): Roles {
+  const roles = emptyRoles();
+  profiles.map(course => {
+    roles[course.role as keyof Roles].add(course.courseId);
   });
+  return roles;
 }

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -1729,6 +1729,13 @@ table tbody tr:last-child > td {
 }
 
 /* Loading Spinner */
+
+.spinner-centered {
+	margin: auto;
+	height: 50px;
+	width: 50px;
+}
+
 .sk-fading-circle {
 	width: 35px;
 	height: 35px;

--- a/csm_web/scheduler/views/matcher.py
+++ b/csm_web/scheduler/views/matcher.py
@@ -342,7 +342,7 @@ def configure(request, pk=None):
         if is_coordinator:
             if matcher is None:
                 # haven't set up the matcher yet
-                return Response([], status=status.HTTP_200_OK)
+                return Response({"open": False, "slots": []}, status=status.HTTP_200_OK)
 
             slots = MatcherSlot.objects.filter(matcher=matcher)
             return Response(

--- a/csm_web/scheduler/views/section.py
+++ b/csm_web/scheduler/views/section.py
@@ -92,7 +92,9 @@ class SectionViewSet(*viewset_with("retrieve", "partial_update", "create")):
             )
             section.spacetimes.set(spacetimes)
             section.save()
-        return Response(status=status.HTTP_201_CREATED)
+
+        serializer = self.serializer_class(section)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def partial_update(self, request, pk=None):
         section = get_object_or_error(self.get_queryset(), pk=pk)

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
@@ -3274,8 +3275,15 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -3305,7 +3313,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3321,6 +3328,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -3543,8 +3565,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -3809,6 +3830,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
@@ -4519,21 +4545,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/flat-cache/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
@@ -4543,8 +4554,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "node_modules/fsevents": {
       "version": "2.3.1",
@@ -4599,7 +4609,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4805,7 +4814,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4814,8 +4822,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.2",
@@ -5177,6 +5184,11 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5395,6 +5407,15 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -5441,6 +5462,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
     "node_modules/mime-db": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -5466,7 +5492,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5497,6 +5522,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -5659,11 +5692,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5773,7 +5810,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6109,6 +6145,31 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/react-query": {
+      "version": "3.39.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
+      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -6261,6 +6322,11 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -6318,6 +6384,20 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-parallel": {
@@ -6960,6 +7040,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -7263,8 +7352,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -9802,8 +9890,12 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -9827,7 +9919,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9840,6 +9931,21 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "browserslist": {
@@ -10006,8 +10112,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -10206,6 +10311,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -10739,17 +10849,6 @@
       "requires": {
         "flatted": "^3.1.0",
         "rimraf": "^3.0.2"
-      },
-      "dependencies": {
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        }
       }
     },
     "flatted": {
@@ -10761,8 +10860,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "2.3.1",
@@ -10804,7 +10902,6 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -10952,7 +11049,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10961,8 +11057,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "internal-slot": {
       "version": "1.0.2",
@@ -11219,6 +11314,11 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11387,6 +11487,15 @@
         }
       }
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -11423,6 +11532,11 @@
         }
       }
     },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
+    },
     "mime-db": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -11442,7 +11556,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11467,6 +11580,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -11584,11 +11705,15 @@
         "has": "^1.0.3"
       }
     },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -11669,8 +11794,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "3.1.1",
@@ -11905,6 +12029,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "react-query": {
+      "version": "3.39.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
+      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -12022,6 +12156,11 @@
         }
       }
     },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -12064,6 +12203,14 @@
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "run-parallel": {
       "version": "1.2.0",
@@ -12522,6 +12669,15 @@
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
+    },
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -12728,8 +12884,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
+        "@tanstack/react-query": "^4.2.3",
         "@types/jest": "^26.0.24",
         "@types/node": "^14.17.5",
         "@types/react": "^18.0.14",
@@ -18,7 +19,6 @@
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
@@ -28,6 +28,7 @@
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.14.5",
         "@svgr/webpack": "^5.5.0",
+        "@tanstack/react-query-devtools": "^4.2.3",
         "@types/js-cookie": "^3.0.2",
         "@types/lodash": "^4.14.175",
         "@types/react-router-dom": "^5.3.3",
@@ -2216,6 +2217,78 @@
         "node": ">=8.9.0"
       }
     },
+    "node_modules/@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "dev": true,
+      "dependencies": {
+        "remove-accents": "0.4.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kentcdodds"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.3.tgz",
+      "integrity": "sha512-zdt5lYWs1dZaA3IxJbCgtAfHZJScRZONpiLL7YkeOkrme5MfjQqTpjq7LYbzpyuwPOh2Jx68le0PLl57JFv5hQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.2.3.tgz",
+      "integrity": "sha512-JLaMOxoJTkiAu7QpevRCt2uI/0vd3E8K/rSlCuRgWlcW5DeJDFpDS5kfzmLO5MOcD97fgsJRrDbxDORxR1FdJA==",
+      "dependencies": {
+        "@tanstack/query-core": "4.2.3",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.2.3.tgz",
+      "integrity": "sha512-0PH8n824BnFyMrtv7q5uLS0b7jYg2tDH8vU4etkSYzV1uL4RJjiqMh7Gyi8qhYCwM+khlrkRYlNZvE0cxlp3SQ==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "4.2.3",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
@@ -2361,6 +2434,11 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@types/yargs": {
       "version": "15.0.14",
@@ -3275,15 +3353,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "node_modules/big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "engines": {
-        "node": ">=0.6"
-      }
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/big.js": {
       "version": "5.2.2",
@@ -3313,6 +3384,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -3328,21 +3400,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "dependencies": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "node_modules/browserslist": {
@@ -3565,7 +3622,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "1.7.0",
@@ -3830,11 +3888,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "node_modules/diff-sequences": {
       "version": "26.6.2",
@@ -4554,7 +4607,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.1",
@@ -4609,6 +4663,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -4814,6 +4869,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4822,7 +4878,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.2",
@@ -5184,11 +5241,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5407,15 +5459,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "node_modules/mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -5462,11 +5505,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "node_modules/mime-db": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -5492,6 +5530,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5522,14 +5561,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "node_modules/nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "dependencies": {
-        "big-integer": "^1.6.16"
-      }
     },
     "node_modules/nanoid": {
       "version": "3.3.4",
@@ -5692,15 +5723,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -5810,6 +5837,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6145,31 +6173,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "node_modules/react-query": {
-      "version": "3.39.1",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
-      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        },
-        "react-native": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -6325,7 +6328,8 @@
     "node_modules/remove-accents": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==",
+      "dev": true
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
@@ -6390,6 +6394,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7040,15 +7045,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -7088,6 +7084,14 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7352,7 +7356,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -9013,6 +9018,41 @@
         }
       }
     },
+    "@tanstack/match-sorter-utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.1.1.tgz",
+      "integrity": "sha512-IdmEekEYxQsoLOR0XQyw3jD1GujBpRRYaGJYQUw1eOT1eUugWxdc7jomh1VQ1EKHcdwDLpLaCz/8y4KraU4T9A==",
+      "dev": true,
+      "requires": {
+        "remove-accents": "0.4.2"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.2.3.tgz",
+      "integrity": "sha512-zdt5lYWs1dZaA3IxJbCgtAfHZJScRZONpiLL7YkeOkrme5MfjQqTpjq7LYbzpyuwPOh2Jx68le0PLl57JFv5hQ=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.2.3.tgz",
+      "integrity": "sha512-JLaMOxoJTkiAu7QpevRCt2uI/0vd3E8K/rSlCuRgWlcW5DeJDFpDS5kfzmLO5MOcD97fgsJRrDbxDORxR1FdJA==",
+      "requires": {
+        "@tanstack/query-core": "4.2.3",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.2.3.tgz",
+      "integrity": "sha512-0PH8n824BnFyMrtv7q5uLS0b7jYg2tDH8vU4etkSYzV1uL4RJjiqMh7Gyi8qhYCwM+khlrkRYlNZvE0cxlp3SQ==",
+      "dev": true,
+      "requires": {
+        "@tanstack/match-sorter-utils": "^8.0.0-alpha.82",
+        "@types/use-sync-external-store": "^0.0.3",
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
@@ -9158,6 +9198,11 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/use-sync-external-store": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "@types/yargs": {
       "version": "15.0.14",
@@ -9890,12 +9935,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "big-integer": {
-      "version": "1.6.51",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "big.js": {
       "version": "5.2.2",
@@ -9919,6 +9960,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -9931,21 +9973,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "broadcast-channel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
-      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
-      "requires": {
-        "@babel/runtime": "^7.7.2",
-        "detect-node": "^2.1.0",
-        "js-sha3": "0.8.0",
-        "microseconds": "0.2.0",
-        "nano-time": "1.0.0",
-        "oblivious-set": "1.0.0",
-        "rimraf": "3.0.2",
-        "unload": "2.2.0"
       }
     },
     "browserslist": {
@@ -10112,7 +10139,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -10311,11 +10339,6 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
-    },
-    "detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -10860,7 +10883,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.1",
@@ -10902,6 +10926,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11049,6 +11074,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -11057,7 +11083,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "internal-slot": {
       "version": "1.0.2",
@@ -11314,11 +11341,6 @@
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
       "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
     },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11487,15 +11509,6 @@
         }
       }
     },
-    "match-sorter": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
-      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
-      "requires": {
-        "@babel/runtime": "^7.12.5",
-        "remove-accents": "0.4.2"
-      }
-    },
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -11532,11 +11545,6 @@
         }
       }
     },
-    "microseconds": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
-      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
-    },
     "mime-db": {
       "version": "1.45.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
@@ -11556,6 +11564,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -11580,14 +11589,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
-    },
-    "nano-time": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
-      "integrity": "sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==",
-      "requires": {
-        "big-integer": "^1.6.16"
-      }
     },
     "nanoid": {
       "version": "3.3.4",
@@ -11705,15 +11706,11 @@
         "has": "^1.0.3"
       }
     },
-    "oblivious-set": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
-      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -11794,7 +11791,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -12029,16 +12027,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
-    "react-query": {
-      "version": "3.39.1",
-      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.1.tgz",
-      "integrity": "sha512-qYKT1bavdDiQZbngWZyPotlBVzcBjDYEJg5RQLBa++5Ix5jjfbEYJmHSZRZD+USVHUSvl/ey9Hu+QfF1QAK80A==",
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "broadcast-channel": "^3.4.1",
-        "match-sorter": "^6.0.2"
-      }
-    },
     "react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -12159,7 +12147,8 @@
     "remove-accents": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
-      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==",
+      "dev": true
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -12208,6 +12197,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -12669,15 +12659,6 @@
       "integrity": "sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==",
       "dev": true
     },
-    "unload": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
-      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
-      "requires": {
-        "@babel/runtime": "^7.6.2",
-        "detect-node": "^2.0.4"
-      }
-    },
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -12702,6 +12683,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -12884,7 +12871,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
     "@svgr/webpack": "^5.5.0",
+    "@tanstack/react-query-devtools": "^4.2.3",
     "@types/js-cookie": "^3.0.2",
     "@types/lodash": "^4.14.175",
     "@types/react-router-dom": "^5.3.3",
@@ -54,6 +55,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.3",
+    "@tanstack/react-query": "^4.2.3",
     "@types/jest": "^26.0.24",
     "@types/node": "^14.17.5",
     "@types/react": "^18.0.14",
@@ -62,7 +64,6 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0"
   }
 }


### PR DESCRIPTION
Resolves #289.

Requests are not handled well in the repository right now, and especially with the migration to React 18, strict mode adds additional mount/unmount operations, causing `useEffect` to fire multiple times upon load. Although this is only an issue in development, it means that we should be dealing with requests not in the `useEffect` hook. React Query handles a lot of the request deduplication, caching, etc., optimizing the queries made to the backend API.