### PR TITLE
Allow students to view sections prior to enrollment

### DIFF
--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -130,8 +130,21 @@ const CourseMenu = ({ match: { path } }: CourseMenuProps) => {
             // only render if loaded
             const course = courses.get(Number(routeProps.match.params.id))!;
             const isOpen = course && course.enrollmentOpen;
+            const isPriority = userInfo && userInfo.priorityEnrollment;
+            const enrollmentDate = isPriority
+              ? userInfo.priorityEnrollment
+              : enrollment_times_by_course.find(({ courseName }) => courseName === course.name)?.enrollmentDate;
             // use key to rerender when manually changing URL
-            return <Course key={course.id} name={loaded && course.name} isOpen={isOpen} {...routeProps} />;
+            return (
+              <Course
+                key={course.id}
+                name={loaded && course.name}
+                isOpen={isOpen}
+                isPriority={isPriority}
+                enrollmentTimeString={enrollmentDate?.toLocaleDateString("en-US", date_locale_string_options) ?? ""}
+                {...routeProps}
+              />
+            );
           }
         }}
       />

--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -75,11 +75,7 @@ const CourseMenu = ({ match: { path } }: CourseMenuProps) => {
       ) : (
         <div id="course-menu">
           {Array.from(courses.entries()).map(([id, course]) => (
-            <Link
-              className={"csm-btn" + (course.enrollmentOpen ? "" : " disabled")}
-              to={course.enrollmentOpen ? `${path}/${id}` : "#"}
-              key={id}
-            >
+            <Link className="csm-btn" to={`${path}/${id}`} key={id}>
               {course.name}
             </Link>
           ))}

--- a/csm_web/frontend/src/components/course/Course.tsx
+++ b/csm_web/frontend/src/components/course/Course.tsx
@@ -33,6 +33,8 @@ interface CourseProps {
    */
   name: boolean | string;
   isOpen: boolean;
+  isPriority: boolean;
+  enrollmentTimeString: string;
 }
 
 const Course = ({
@@ -40,7 +42,9 @@ const Course = ({
     params: { id }
   },
   name,
-  isOpen
+  isOpen,
+  isPriority,
+  enrollmentTimeString
 }: CourseProps): React.ReactElement | null => {
   /**
    * Sections grouped by day of the week.
@@ -164,6 +168,13 @@ const Course = ({
             >
               Export Data
             </button>
+          </div>
+        )}
+        {!isOpen && (
+          <div id="course-enrollment-open-status">
+            {isPriority
+              ? `Priority enrollment opens ${enrollmentTimeString}.`
+              : `Enrollment opens ${enrollmentTimeString}.`}
           </div>
         )}
       </div>

--- a/csm_web/frontend/src/components/course/Course.tsx
+++ b/csm_web/frontend/src/components/course/Course.tsx
@@ -115,11 +115,6 @@ const Course = ({
     currDaySections = currDaySections.filter(({ numStudentsEnrolled, capacity }) => numStudentsEnrolled < capacity);
   }
 
-  // only let coordinators see the course if enrollment is not open
-  if (!isOpen && sectionsLoaded && !userIsCoordinator) {
-    return <h3 className="page-title center-title">Enrollment is not open.</h3>;
-  }
-
   return !(name && sectionsLoaded) ? null : (
     <div id="course-section-selector">
       <div id="course-section-controls">
@@ -175,7 +170,7 @@ const Course = ({
       <div id="course-section-list">
         {currDaySections && currDaySections.length > 0 ? (
           currDaySections.map(section => (
-            <SectionCard key={section.id} userIsCoordinator={userIsCoordinator} {...section} />
+            <SectionCard key={section.id} userIsCoordinator={userIsCoordinator} courseOpen={isOpen} {...section} />
           ))
         ) : (
           <h3 id="course-section-list-empty">No sections available, please select a different day</h3>

--- a/csm_web/frontend/src/components/course/SectionCard.tsx
+++ b/csm_web/frontend/src/components/course/SectionCard.tsx
@@ -18,6 +18,7 @@ interface SectionCardProps {
   capacity: number;
   description: string;
   userIsCoordinator: boolean;
+  courseOpen: boolean;
 }
 
 export const SectionCard = ({
@@ -27,7 +28,8 @@ export const SectionCard = ({
   numStudentsEnrolled,
   capacity,
   description,
-  userIsCoordinator
+  userIsCoordinator,
+  courseOpen
 }: SectionCardProps): React.ReactElement => {
   /**
    * Whether to show the modal (after an attempt to enroll).
@@ -48,6 +50,13 @@ export const SectionCard = ({
   const enroll = () => {
     interface FetchJSON {
       detail: string;
+    }
+
+    if (!courseOpen) {
+      setShowModal(true);
+      setEnrollmentSuccessful(false);
+      setErrorMessage("The course is not open for enrollment.");
+      return;
     }
 
     fetchWithMethod(`sections/${id}/students/`, HTTP_METHODS.PUT)
@@ -173,7 +182,10 @@ export const SectionCard = ({
             MANAGE
           </Link>
         ) : (
-          <div className="csm-btn section-card-footer" onClick={isFull ? undefined : enroll}>
+          <div
+            className={`csm-btn section-card-footer ${courseOpen ? "" : "disabled"}`}
+            onClick={isFull ? undefined : enroll}
+          >
             ENROLL
           </div>
         )}

--- a/csm_web/frontend/static/frontend/css/style.css
+++ b/csm_web/frontend/static/frontend/css/style.css
@@ -545,6 +545,16 @@ header {
 	margin: 0 auto;
 }
 
+#course-enrollment-open-status {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+
+	margin: 20px 0;
+	color: #6d6d6d;
+}
+
 .course-title {
 	color: #6d6d6d;
 	font-size: 2.5em;

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -83,7 +83,7 @@ class CourseSerializer(serializers.ModelSerializer):
 
     def get_enrollment_open(self, obj):
         user = self.context.get('request') and self.context.get('request').user
-        if user and user.priority_enrollment:
+        if user and user.priority_enrollment and user.priority_enrollment < obj.enrollment_start:
             now = timezone.now().astimezone(timezone.get_default_timezone())
             return user.priority_enrollment < now < obj.enrollment_end
         else:

--- a/csm_web/scheduler/views/section.py
+++ b/csm_web/scheduler/views/section.py
@@ -438,7 +438,7 @@ class SectionViewSet(*viewset_with("retrieve", "partial_update", "create")):
                 f"<Enrollment:Failure> User {log_str(request.user)} was unable to enroll in Section {log_str(section)} because they are already involved in this course"
             )
             raise PermissionDenied(
-                "You are already either mentoring for this course or enrolled in a section",
+                "You are already either mentoring for this course or enrolled in a section, or the course is closed for enrollment",
                 status.HTTP_422_UNPROCESSABLE_ENTITY,
             )
         if section.current_student_count >= section.capacity:


### PR DESCRIPTION
Resolves #257.

This PR
* Refactors the course menu to allow anybody to view sections for any course at any time
* Reworks the section cards to disable enroll buttons before the course is open
* Fixes bug in enrollment time display if priority enrollment is after normal course enrollment
* Adds status on course pages to show enrollment time for the specific course