### PR TITLE
Fix calendar resize event bug

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
@@ -101,6 +101,7 @@ export function Calendar({
     setIntervalWidth(rect.width * WIDTH_SCALE);
 
     const resizeHandler = () => {
+      const interval = document.getElementsByClassName("calendar-day-interval").item(0);
       const rect = interval!.getBoundingClientRect();
       setIntervalHeight(rect.height);
       setIntervalWidth(rect.width * WIDTH_SCALE);

--- a/csm_web/frontend/static/frontend/css/calendar.css
+++ b/csm_web/frontend/static/frontend/css/calendar.css
@@ -68,7 +68,7 @@ Hierarchy:
 	flex-direction: column;
 	justify-content: stretch;
 	align-items: center;
-	padding-top: 8px;
+	padding: 8px 0;
 }
 
 .calendar-day-interval {

--- a/csm_web/scheduler/utils/match_solver.py
+++ b/csm_web/scheduler/utils/match_solver.py
@@ -1,5 +1,4 @@
 import networkx as nx
-from pprint import pprint
 from collections import namedtuple
 import itertools
 
@@ -88,7 +87,6 @@ def get_matches(mentors, slots, preferences):
     flow_cost, flow_dict = nx.network_simplex(G)
     mentors_set = set(itertools.chain(*mentors))
     assignments = {}
-    pprint(flow_dict)
     for u in flow_dict:
         for v in flow_dict[u]:
             if (


### PR DESCRIPTION
Resizing the window and scrolling the calendar sometimes causes the events to disappear. Hopefully this fixes the bug.

Also, removed a debug print statement from the matcher function.