### PR TITLE
Add filter to course mentor set when creating sections

### DIFF
--- a/csm_web/scheduler/views/section.py
+++ b/csm_web/scheduler/views/section.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.db import transaction
 from django.db.models import Q, Prefetch
 from django.utils import timezone
@@ -60,7 +62,11 @@ class SectionViewSet(*viewset_with("retrieve", "partial_update", "create")):
                 email=self.request.data["mentor_email"],
                 username=self.request.data["mentor_email"].split("@")[0],
             )
-            duration = course.mentor_set.first().section.spacetimes.first().duration
+            mentors_with_sections = course.mentor_set.filter(section__isnull=False)
+            if mentors_with_sections.count() > 0:
+                duration = mentors_with_sections.first().section.spacetimes.first().duration
+            else:
+                duration = datetime.timedelta(hours=1)  # default duration is 1 hour
             spacetime_serializers = [
                 SpacetimeSerializer(data={**spacetime, "duration": str(duration)})
                 for spacetime in self.request.data["spacetimes"]


### PR DESCRIPTION
Sentry issue: https://sentry.io/share/issue/9cc6519093e3485cb1cfb7bd6e419c80/

When creating a new section, if the first mentor in the mentor set of a course has no section, the request fails, since it fetches the duration from an existing section.

To fix this issue, an additional filter is made prior to fetching a previous section, so ensure that we're never getting a null section. Further, the duration default is set to one hour, in case no sections have been created yet.

Future improvement would be to add a field for duration when creating sections.