### PR TITLE
Fix matcher create stage tooltip, add tooltip jsdoc

### DIFF
--- a/csm_web/frontend/src/components/Tooltip.tsx
+++ b/csm_web/frontend/src/components/Tooltip.tsx
@@ -4,29 +4,24 @@ interface TooltipProps {
   className?: string;
   bodyClassName?: string;
   source: React.ReactNode;
-  activation: TooltipActivation;
   children: React.ReactChild | React.ReactChild[];
   placement: "top" | "bottom" | "left" | "right";
 }
 
-enum TooltipActivation {
-  Hover,
-  Click
-}
-
-export const Tooltip = ({ className, bodyClassName, source, activation, placement, children }: TooltipProps) => {
+/**
+ * Tooltip for displaying additional information on hover.
+ *
+ * Must be surrounded by a parent element with position: relative.
+ */
+export const Tooltip = ({ className, bodyClassName, source, placement, children }: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const handleMouseEnter = () => {
-    if (activation === TooltipActivation.Hover) {
-      setIsOpen(true);
-    }
+    setIsOpen(true);
   };
 
   const handleMouseLeave = () => {
-    if (activation === TooltipActivation.Hover) {
-      setIsOpen(false);
-    }
+    setIsOpen(false);
   };
 
   let top, left, transform;
@@ -71,8 +66,4 @@ export const Tooltip = ({ className, bodyClassName, source, activation, placemen
       </div>
     </div>
   );
-};
-
-Tooltip.defaultProps = {
-  activation: TooltipActivation.Hover
 };

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/CreateStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/CreateStage.tsx
@@ -431,11 +431,13 @@ export function CreateStage({ profile, initialSlots, refreshStage }: CreateStage
                   <input type="checkbox" defaultChecked onChange={editTiled_linked} />
                   Link days?
                 </label>
-                <Tooltip placement="right" source={<InfoIcon className="icon matcher-tooltip-info-icon" />}>
-                  <div className="matcher-tiling-tooltip-body">
-                    Associate the same times across selected days with a single event.
-                  </div>
-                </Tooltip>
+                <div className="matcher-tooltip-container">
+                  <Tooltip placement="right" source={<InfoIcon className="icon matcher-tooltip-info-icon" />}>
+                    <div className="matcher-tiling-tooltip-body">
+                      Associate the same times across selected days with a single event.
+                    </div>
+                  </Tooltip>
+                </div>
               </div>
             </div>
 

--- a/csm_web/frontend/static/frontend/css/enrollment_matcher.css
+++ b/csm_web/frontend/static/frontend/css/enrollment_matcher.css
@@ -412,6 +412,10 @@
 	margin-bottom: 3px;
 }
 
+.matcher-tooltip-container {
+	position: relative;
+}
+
 .matcher-tooltip-info-icon {
 	width: 1em;
 	margin-left: 3px;


### PR DESCRIPTION
Previous changes for the matcher feature had a bug with tooltips not showing in the create stage. Root of the issue was a missing parent element with `position: relative`; this is fixed in this PR, and additional documentation is added to the tooltip class as an attempt to prevent this in the future. Further, since a click activation for the tooltip would require event listeners and further design, this PR removes that feature, as it's not currently being used.

I've looked into modifying the tooltip component so that it doesn't need to be surrounded by a parent with `position: relative`, but this breaks the tooltips if used in the calendar—the event details are surrounded with a div with `overflow: hidden`, which would prevent the tooltips from showing. Circumventing this would require more redesign of how calendar event details are rendered.

As such, a compromise is to leave the design as-is, and put a note for future uses to wrap the element in a parent with `position: relative`.