### PR TITLE
Add matcher mentor preference validation

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
@@ -96,12 +96,16 @@ export function MentorSectionPreferences({
     }
 
     const selectedEventIds = selectedEvents.map(event => event.id);
+    let intPreference = parseInt(e.target.value);
+
+    // clamp preference value
+    intPreference = Math.min(MAX_PREFERENCE, Math.max(0, intPreference));
 
     const newSlots = slots.map(slot => {
       if (selectedEventIds.includes(slot.id)) {
         return {
           ...slot,
-          preference: parseInt(e.target.value)
+          preference: intPreference
         };
       }
       return slot;
@@ -115,7 +119,7 @@ export function MentorSectionPreferences({
     for (const slot of slots) {
       const cleaned_slot = {
         id: slot.id!,
-        preference: slot.preference
+        preference: Math.min(MAX_PREFERENCE, Math.max(0, slot.preference))
       };
       cleaned_preferences.push(cleaned_slot);
     }


### PR DESCRIPTION
Resolves #318.

Modified the frontend form submission to clamp the mentor preferences between 0 and `MAX_PREFERENCE`. There isn't really any good way to validate this value in the backend, as we want to be agnostic to different preference values, and having two places to change this setting will just allow more bugs in the future, but this could be redesigned/thought about later.