### PR TITLE
Add validation when adding mentor emails

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/ReleaseStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/ReleaseStage.tsx
@@ -194,6 +194,13 @@ function MentorList({
       // split by newline
       newMentors = newMentorsString.split("\n").map(email => email.trim());
     }
+    // filter empty emails
+    newMentors = newMentors.filter(email => email.length > 0);
+
+    if (newMentors.length == 0) {
+      // nothing to request
+      return;
+    }
 
     // submit mentor list to add to course
     fetchWithMethod(`matcher/${profile.courseId}/mentors`, HTTP_METHODS.POST, {

--- a/csm_web/scheduler/views/matcher.py
+++ b/csm_web/scheduler/views/matcher.py
@@ -275,15 +275,19 @@ def mentors(request, pk=None):
         # users already associated with the course as a mentor
         users_with_course = User.objects.filter(mentor__course=course)
         for email in request.data["mentors"]:
-            username = email.split("@")[0]  # username is everything before @
-            # use existing user, or create a new user if it doesnt exist
-            user, _ = User.objects.get_or_create(username=username, email=email)
-            # if mentor exists, skip
-            if user in users_with_course:
+            if not email or "@" not in email:
+                # invalid or blank email
                 skipped.append(email)
-                continue
-            # create new mentor
-            created = Mentor.objects.create(user=user, course=course)
+            else:
+                username = email.split("@")[0]  # username is everything before @
+                # use existing user, or create a new user if it doesnt exist
+                user, _ = User.objects.get_or_create(username=username, email=email)
+                # if mentor exists, skip
+                if user in users_with_course:
+                    skipped.append(email)
+                    continue
+                # create new mentor
+                created = Mentor.objects.create(user=user, course=course)
         return Response({"skipped": skipped}, status=status.HTTP_200_OK)
     elif request.method == "DELETE":
         # delete mentors from course


### PR DESCRIPTION
Resolves #309.

Modified the frontend to filter out empty emails (after trimming) before sending the request; doesn't send the request if this filter removes all emails.

Additionally, modified the backend to skip over any invalid emails (i.e. emails that do not contain `@`, or any blank emails). This serves as an additional net to catch anything that slips through from the frontend.