### PR TITLE
Reorganize matcher stages, mentor matcher visibility

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
@@ -8,7 +8,6 @@ import { formatInterval, formatTime, MAX_PREFERENCE, parseTime } from "./utils";
 
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
 import {
-  useMatcherConfig,
   useMatcherPreferenceMutation,
   useMatcherPreferences,
   useMatcherSlots
@@ -45,7 +44,6 @@ export function MentorSectionPreferences({
 
   const { data: jsonSlots, isSuccess: jsonSlotsLoaded } = useMatcherSlots(profile.courseId);
   const { data: jsonPreferences, isSuccess: jsonPreferencesLoaded } = useMatcherPreferences(profile.courseId);
-  const { data: matcherConfig, isSuccess: matcherConfigLoaded } = useMatcherConfig(profile.courseId);
 
   const matcherPreferenceMutation = useMatcherPreferenceMutation(profile.courseId);
 
@@ -84,10 +82,6 @@ export function MentorSectionPreferences({
 
     setSlots(newSlots);
   }, [jsonSlotsLoaded, jsonPreferencesLoaded]);
-
-  if (!matcherConfigLoaded) {
-    return <LoadingSpinner className="spinner-centered" />;
-  }
 
   const setPreference = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newPreference = parseInt(e.target.value);
@@ -140,13 +134,8 @@ export function MentorSectionPreferences({
   };
 
   const setSelectedEventIndicesWrapper = (indices: number[]) => {
-    if (matcherConfig.open) {
-      setSelectedEventIndices(indices);
-      setSelectedEvents(indices.map(idx => slots[idx]));
-    } else {
-      setSelectedEventIndices([]);
-      setSelectedEvents([]);
-    }
+    setSelectedEventIndices(indices);
+    setSelectedEvents(indices.map(idx => slots[idx]));
   };
 
   const getEventDetails = (event: CalendarEventSingleTime): React.ReactElement => {
@@ -174,60 +163,55 @@ export function MentorSectionPreferences({
   };
 
   let sidebarContents;
-  if (matcherConfig.open) {
-    if (selectedEvents.length === 0) {
-      // no selected event
-      sidebarContents = <div>Click on a section to edit preferences.</div>;
-    } else {
-      const event = selectedEvents[0];
-      sidebarContents = (
-        <div className="matcher-sidebar-selected">
-          <div className="mathcer-sidebar-selected-top">
-            {selectedEvents.length === 1 ? (
-              // exactly one selected event
-              <React.Fragment>
-                <div className="matcher-sidebar-header">Section Time{event.times.length > 1 ? "s" : ""}:</div>
-                <ul className="matcher-selected-times">
-                  {event.times.map((time, time_idx) => (
-                    <li key={time_idx} className="matcher-selected-time-container">
-                      <span className="matcher-selected-time">
-                        {time.day} {formatTime(time.startTime)}&#8211;{formatTime(time.endTime)}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </React.Fragment>
-            ) : (
-              // multiple selected events
-              <div className="matcher-sidebar-header">Multiple selected events</div>
-            )}
-            <label>
-              Preference:
-              <input
-                className="matcher-input"
-                type="number"
-                key={event.id}
-                defaultValue={event.preference}
-                onChange={setPreference}
-                autoFocus={true}
-                min={0}
-                max={MAX_PREFERENCE}
-              />
-            </label>
-          </div>
-          <div className="matcher-sidebar-create-footer">
-            <div className="matcher-sidebar-pref-help">
-              Rate your preferences from 0 to {MAX_PREFERENCE}.
-              <br />0 means unavailable, {MAX_PREFERENCE} means most preferred.
-            </div>
-            <div>Shift-click to select more slots.</div>
-          </div>
-        </div>
-      );
-    }
+  if (selectedEvents.length === 0) {
+    // no selected event
+    sidebarContents = <div>Click on a section to edit preferences.</div>;
   } else {
-    // matcher closed
-    sidebarContents = <div>The matcher is not currently open for preference submission.</div>;
+    const event = selectedEvents[0];
+    sidebarContents = (
+      <div className="matcher-sidebar-selected">
+        <div className="mathcer-sidebar-selected-top">
+          {selectedEvents.length === 1 ? (
+            // exactly one selected event
+            <React.Fragment>
+              <div className="matcher-sidebar-header">Section Time{event.times.length > 1 ? "s" : ""}:</div>
+              <ul className="matcher-selected-times">
+                {event.times.map((time, time_idx) => (
+                  <li key={time_idx} className="matcher-selected-time-container">
+                    <span className="matcher-selected-time">
+                      {time.day} {formatTime(time.startTime)}&#8211;{formatTime(time.endTime)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </React.Fragment>
+          ) : (
+            // multiple selected events
+            <div className="matcher-sidebar-header">Multiple selected events</div>
+          )}
+          <label>
+            Preference:
+            <input
+              className="matcher-input"
+              type="number"
+              key={event.id}
+              defaultValue={event.preference}
+              onChange={setPreference}
+              autoFocus={true}
+              min={0}
+              max={MAX_PREFERENCE}
+            />
+          </label>
+        </div>
+        <div className="matcher-sidebar-create-footer">
+          <div className="matcher-sidebar-pref-help">
+            Rate your preferences from 0 to {MAX_PREFERENCE}.
+            <br />0 means unavailable, {MAX_PREFERENCE} means most preferred.
+          </div>
+          <div>Shift-click to select more slots.</div>
+        </div>
+      </div>
+    );
   }
 
   let statusContent: React.ReactNode = "";
@@ -255,7 +239,7 @@ export function MentorSectionPreferences({
         <div className="mentor-sidebar-left">
           <div className="matcher-sidebar-left-top">{sidebarContents}</div>
           <div className="matcher-sidebar-left-bottom-row">
-            <button className="matcher-submit-btn" onClick={postPreferences} disabled={!matcherConfig.open}>
+            <button className="matcher-submit-btn" onClick={postPreferences}>
               Submit
             </button>
             <div className="matcher-submit-status-container">{statusContent}</div>

--- a/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
@@ -7,11 +7,7 @@ import { Slot } from "./EnrollmentAutomationTypes";
 import { formatInterval, formatTime, MAX_PREFERENCE, parseTime } from "./utils";
 
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
-import {
-  useMatcherPreferenceMutation,
-  useMatcherPreferences,
-  useMatcherSlots
-} from "../../utils/queries/matcher";
+import { useMatcherPreferenceMutation, useMatcherPreferences, useMatcherSlots } from "../../utils/queries/matcher";
 
 enum Status {
   NONE,

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/CoordinatorMatcherForm.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/CoordinatorMatcherForm.tsx
@@ -186,6 +186,7 @@ export function CoordinatorMatcherForm({
           prefByMentor={prefByMentor}
           assignments={assignments}
           recomputeStage={recomputeStage}
+          formIsOpen={formIsOpen}
           setCurStage={setCurStage}
         />
       </div>
@@ -200,6 +201,7 @@ interface CoordinatorMatcherFormSwitchProps {
   prefByMentor: Map<number, SlotPreference[]>;
   assignments: Assignment[];
   recomputeStage: () => void;
+  formIsOpen: boolean;
   setCurStage: (stage: Stage) => void;
 }
 
@@ -210,13 +212,22 @@ const CoordinatorMatcherFormSwitch = ({
   prefByMentor,
   assignments,
   recomputeStage,
+  formIsOpen,
   setCurStage
 }: CoordinatorMatcherFormSwitchProps) => {
   switch (stage) {
     case Stage.CREATE:
-      return <CreateStage profile={profile} initialSlots={slots} />;
+      return <CreateStage profile={profile} initialSlots={slots} nextStage={() => setCurStage(Stage.RELEASE)} />;
     case Stage.RELEASE:
-      return <ReleaseStage profile={profile} slots={slots} prefByMentor={prefByMentor} />;
+      return (
+        <ReleaseStage
+          profile={profile}
+          slots={slots}
+          prefByMentor={prefByMentor}
+          prevStage={() => setCurStage(Stage.CREATE)}
+          formIsOpen={formIsOpen}
+        />
+      );
     case Stage.CONFIGURE:
       return <ConfigureStage profile={profile} slots={slots} recomputeStage={recomputeStage} />;
     case Stage.EDIT:

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/CreateStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/CreateStage.tsx
@@ -23,9 +23,10 @@ interface TileDetails {
 interface CreateStageProps {
   profile: Profile;
   initialSlots: Slot[];
+  nextStage: () => void;
 }
 
-export function CreateStage({ profile, initialSlots }: CreateStageProps): JSX.Element {
+export function CreateStage({ profile, initialSlots, nextStage }: CreateStageProps): JSX.Element {
   /**
    * List of slots to be displayed in the calendar.
    */
@@ -145,11 +146,6 @@ export function CreateStage({ profile, initialSlots }: CreateStageProps): JSX.El
         }
       }
     );
-  };
-
-  const openForm = (): void => {
-    // send POST request to release form for mentors
-    matcherConfigMutation.mutate({ open: true });
   };
 
   /**
@@ -623,8 +619,8 @@ export function CreateStage({ profile, initialSlots }: CreateStageProps): JSX.El
         <div className="matcher-unsaved-changes-container">
           {edited && <span className="matcher-unsaved-changes">You have unsaved changes!</span>}
         </div>
-        <button className="matcher-submit-btn" onClick={openForm} disabled={edited}>
-          Release Form
+        <button className="matcher-submit-btn" onClick={nextStage} disabled={edited}>
+          Continue
         </button>
       </div>
     </React.Fragment>

--- a/csm_web/frontend/static/frontend/css/enrollment_matcher.css
+++ b/csm_web/frontend/static/frontend/css/enrollment_matcher.css
@@ -103,6 +103,19 @@
 	background: linear-gradient(to bottom, #ffffff99 0%, #ffffff 50%);
 }
 
+.matcher-body-footer-status-container {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+}
+
+.matcher-body-footer-status-icon {
+	width: 2em !important;
+	height: 2em !important;
+}
+
 .mentor-sidebar-left,
 .coordinator-sidebar-left {
 	display: flex;


### PR DESCRIPTION
Resolves #308.

Reorganized matcher stages to move opening the matcher to the Release stage. This means that coordinators can add and edit mentor lists before opening the matcher.

Also modified the API endpoint for active matcher courses, omitting courses for mentors if the matcher is closed. This prevents the leak of information in the time period before mentors get their application decisions and after coordinators set up the scheduler for matcher preference submission.