### PR TITLE
Add heroku release phase for database migration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: cd csm_web; gunicorn csm_web.wsgi
+release: ./release.sh

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+python3 csm_web/manage.py migrate


### PR DESCRIPTION
Modified the `Procfile` for Heroku to automatically migrate the postgres database after a release.

This can be expanded and added to further if more tasks are required in the future.