### PR TITLE
Update view responses to return modified data

### DIFF
--- a/csm_web/scheduler/views/profile.py
+++ b/csm_web/scheduler/views/profile.py
@@ -1,9 +1,9 @@
-from .utils import viewset_with
-
 from django.db.models.query import EmptyQuerySet
 from rest_framework.response import Response
+from rest_framework import status
+from scheduler.serializers import ProfileSerializer
 
-from ..serializers import ProfileSerializer
+from .utils import viewset_with
 
 
 class ProfileViewSet(*viewset_with("list")):
@@ -19,5 +19,6 @@ class ProfileViewSet(*viewset_with("list")):
                     *request.user.coordinator_set.all(),
                 ],
                 many=True,
-            ).data
+            ).data,
+            status=status.HTTP_200_OK
         )

--- a/csm_web/scheduler/views/user.py
+++ b/csm_web/scheduler/views/user.py
@@ -1,11 +1,11 @@
-from rest_framework.exceptions import PermissionDenied
-from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.decorators import api_view
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
+from scheduler.models import Coordinator, User
+from scheduler.serializers import UserSerializer
 
 from .utils import viewset_with
-from ..models import Coordinator, User
-from scheduler.serializers import UserSerializer
 
 
 class UserViewSet(*viewset_with("list")):
@@ -20,7 +20,10 @@ class UserViewSet(*viewset_with("list")):
             raise PermissionDenied(
                 "Only coordinators and superusers may view the user email list"
             )
-        return Response(self.queryset.order_by("email").values_list("email", flat=True))
+        return Response(
+            self.queryset.order_by("email").values_list("email", flat=True),
+            status=status.HTTP_200_OK,
+        )
 
 
 @api_view(["GET"])

--- a/csm_web/scheduler/views/utils.py
+++ b/csm_web/scheduler/views/utils.py
@@ -7,8 +7,7 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework import mixins, viewsets
-
-from ..models import User, Section, Spacetime, Override, Attendance
+from scheduler.models import Attendance, Override, Section, Spacetime, User
 
 logger = logging.getLogger(__name__)
 logger.info = logger.warning
@@ -31,7 +30,9 @@ def log_str(obj) -> str:
         if isinstance(obj, Section):
             return log_format("pk", "mentor.course.name", "spacetimes.all")
         if isinstance(obj, Spacetime):
-            return log_format("pk", "section.mentor.course.name", "location", "start_time")
+            return log_format(
+                "pk", "section.mentor.course.name", "location", "start_time"
+            )
         if isinstance(obj, Override):
             return log_format("pk", "date", "spacetime.pk")
         if isinstance(obj, Attendance):


### PR DESCRIPTION
The Django views are currently inconsistent in what they return for `PUT` or `POST` requests. It's hard to say what the general convention or consensus seems to be regarding this point, but in our specific use case, it's easier to handle responses in the frontend queries if all endpoints return the modified or created resource. This way, we don't need to pass down any other fields from parent components (we'd only need the immediately relevant fields for the request, not the effects of the request), and the query handler has all the information necessary to invalidate any queries.

In the process of making this change, the views files have also been reformatted.