### PR TITLE
Refactor cypress tests to fix retryability flaking

### DIFF
--- a/cypress/e2e/course/coordinator-course.cy.ts
+++ b/cypress/e2e/course/coordinator-course.cy.ts
@@ -8,7 +8,7 @@ before(() => {
  */
 const timeStringToDate = (time: string): Date => {
   // extract hours, minutes, am/pm
-  const [_, hours_str, minutes, ampm] = time.match(/(\d\d?):(\d\d) (AM|PM)/);
+  const [, hours_str, minutes, ampm] = time.match(/(\d\d?):(\d\d) (AM|PM)/);
 
   let hours = parseInt(hours_str);
   if (ampm === "PM" && hours !== 12) {
@@ -24,7 +24,7 @@ const timeStringToDate = (time: string): Date => {
 /**
  * Check that the capacity of a section card is as expected
  */
-const checkCapacity = (text: string, isFull: boolean = false) => {
+const checkCapacity = (text: string, isFull = false) => {
   const groups = text.trim().match(/^(\d+)\/(\d+)$/i);
   if (isFull) {
     expect(parseInt(groups[1]) / parseInt(groups[2])).to.be.eq(1);

--- a/cypress/e2e/course/restricted-courses.cy.ts
+++ b/cypress/e2e/course/restricted-courses.cy.ts
@@ -93,15 +93,13 @@ describe("whitelisted courses", () => {
     cy.contains(".csm-btn", /cs61a/i).should("be.visible");
 
     // view unrestricted courses; should show nothing
-    cy.contains(".course-menu-sidebar-tab", /unrestricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).should("not.exist");
 
     // go to cs61a sections
-    cy.contains(".course-menu-sidebar-tab", /restricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).click();
     cy.get(".section-card").should("have.length", 1).should("be.visible");
 
@@ -145,16 +143,14 @@ describe("whitelisted courses", () => {
     cy.contains(".csm-btn", /cs70/i).should("not.exist");
 
     // view unrestricted courses; should show cs70, but not cs61a
-    cy.contains(".course-menu-sidebar-tab", /unrestricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).should("not.exist");
     cy.contains(".csm-btn", /cs70/i).should("be.visible");
 
     // go to cs61a sections
-    cy.contains(".course-menu-sidebar-tab", /restricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).click();
     cy.get(".section-card").should("have.length", 1).should("be.visible");
 
@@ -229,18 +225,16 @@ describe("whitelisted courses", () => {
     cy.contains(".enrollment-container .enrollment-course", /cs61a/i).should("be.visible");
 
     // view unrestricted courses; should show cs70, but not cs61a
-    cy.contains(".course-menu-sidebar-tab", /unrestricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /unrestricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).should("not.exist");
     cy.contains(".csm-btn", /cs70/i).should("be.visible");
     // should not show any enrollment times
     cy.get(".enrollment-container").should("not.exist");
 
     // go to cs61a sections
-    cy.contains(".course-menu-sidebar-tab", /restricted/i)
-      .click()
-      .should("have.class", "active");
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).click();
+    cy.contains(".course-menu-sidebar-tab", /restricted/i).should("have.class", "active");
     cy.contains(".csm-btn", /cs61a/i).click();
     cy.get(".section-card").should("have.length", 1).should("be.visible");
 
@@ -270,7 +264,8 @@ describe("whitelisted courses", () => {
       .should("match", /enrollment failed/i);
 
     // dismiss modal
-    cy.contains(".modal-contents .modal-btn", /ok/i).click().should("not.exist");
+    cy.contains(".modal-contents .modal-btn", /ok/i).click();
+    cy.get(".modal-contents").should("not.exist");
 
     // go back to home page
     cy.visit("/");

--- a/cypress/e2e/section/coordinator-section.cy.ts
+++ b/cypress/e2e/section/coordinator-section.cy.ts
@@ -164,37 +164,37 @@ describe("modifying students", () => {
       cy.wait("@section-students");
       cy.get(".coordinator-email-modal-button").click();
 
-      cy.get(".coordinator-add-student-modal")
-        .within(() => {
-          cy.get(".coordinator-email-input").type(USERNAME);
-          cy.get(".coordinator-email-input-submit").click();
+      cy.get(".coordinator-add-student-modal").within(() => {
+        cy.get(".coordinator-email-input").type(USERNAME);
+        cy.get(".coordinator-email-input-submit").click();
 
-          // wait for request; should fail
-          cy.wait("@add-student").its("response.statusCode").should("eq", 422);
+        // wait for request; should fail
+        cy.wait("@add-student").its("response.statusCode").should("eq", 422);
 
-          cy.contains(".coordinator-email-response-container", /section conflict/i)
-            .within(() => {
-              // should display section conflict
-              cy.contains(".coordinator-email-response-status-conflict", /section conflict/i).should("be.visible");
+        cy.contains(".coordinator-email-response-container", /section conflict/i).within(() => {
+          // should display section conflict
+          cy.contains(".coordinator-email-response-status-conflict", /section conflict/i).should("be.visible");
 
-              cy.contains(".coordinator-email-response-item", USERNAME)
-                .within(() => {
-                  // check text objects
-                  cy.contains("span", USERNAME).should("be.visible");
-                  cy.contains("div", /User is already a mentor for the course/i).should("be.visible");
-                  cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("be.disabled");
+          cy.contains(".coordinator-email-response-item", USERNAME).within(() => {
+            // check text objects
+            cy.contains("span", USERNAME).should("be.visible");
+            cy.contains("div", /User is already a mentor for the course/i).should("be.visible");
+            cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("be.disabled");
 
-                  // remove email
-                  cy.get("span.inline-plus-sign").click().should("not.exist");
-                })
-                .should("not.exist"); // should disappear after click
-            })
-            .should("not.exist"); // should disappear after click
+            // remove email
+            cy.get("span.inline-plus-sign").click().should("not.exist");
+          });
+          // should disappear after click
+          cy.contains(".coordinator-email-response-item", USERNAME).should("not.exist");
+        });
+        // should disappear after click
+        cy.contains(".coordinator-email-response-container", /section conflict/i).should("not.exist");
 
-          cy.contains(".coordinator-email-input-submit", /retry/i).click();
-          // no request, so no wait
-        })
-        .should("not.exist"); // should disappear after click
+        cy.contains(".coordinator-email-input-submit", /retry/i).click();
+        // no request, so no wait
+      });
+      // should disappear after click
+      cy.get(".coordinator-add-student-modal").should("not.exist");
 
       // students should stay the same
       cy.get("#students-table span.student-info")
@@ -264,32 +264,32 @@ describe("modifying students", () => {
       cy.wait("@section-students");
       cy.get(".coordinator-email-modal-button").click();
 
-      cy.get(".coordinator-add-student-modal")
-        .within(() => {
-          cy.get(".coordinator-email-input").type(USERNAME);
-          cy.get(".coordinator-email-input-submit").click();
+      cy.get(".coordinator-add-student-modal").within(() => {
+        cy.get(".coordinator-email-input").type(USERNAME);
+        cy.get(".coordinator-email-input-submit").click();
 
-          // wait for request; should fail
-          cy.wait("@add-student").its("response.statusCode").should("eq", 422);
+        // wait for request; should fail
+        cy.wait("@add-student").its("response.statusCode").should("eq", 422);
 
-          cy.contains(".coordinator-email-response-container", /student banned/i).within(() => {
-            cy.contains(".coordinator-email-response-status-banned", /student banned/i).should("be.visible");
+        cy.contains(".coordinator-email-response-container", /student banned/i).within(() => {
+          cy.contains(".coordinator-email-response-status-banned", /student banned/i).should("be.visible");
 
-            cy.contains(".coordinator-email-response-item", USERNAME).within(() => {
-              // get actual text object
-              cy.contains("span", USERNAME).should("be.visible");
-              // unban and enroll student
-              cy.get("input[type='radio'][value='UNBAN_ENROLL']")
-                .should("have.length", 1)
-                .should("not.be.disabled")
-                .click();
-            });
+          cy.contains(".coordinator-email-response-item", USERNAME).within(() => {
+            // get actual text object
+            cy.contains("span", USERNAME).should("be.visible");
+            // unban and enroll student
+            cy.get("input[type='radio'][value='UNBAN_ENROLL']")
+              .should("have.length", 1)
+              .should("not.be.disabled")
+              .click();
           });
+        });
 
-          cy.contains(".coordinator-email-input-submit", /retry/i).click();
-          cy.wait("@add-student").its("response.statusCode").should("eq", 200);
-        })
-        .should("not.exist"); // should disappear after click
+        cy.contains(".coordinator-email-input-submit", /retry/i).click();
+        cy.wait("@add-student").its("response.statusCode").should("eq", 200);
+      });
+
+      cy.get(".coordinator-add-student-modal").should("not.exist"); // should disappear after click
 
       cy.wait("@section-students");
 
@@ -308,25 +308,25 @@ describe("modifying students", () => {
       cy.wait("@section-students");
       cy.get(".coordinator-email-modal-button").click();
 
-      cy.get(".coordinator-add-student-modal")
-        .within(() => {
-          cy.get(".coordinator-email-input").type("testuser1@berkeley.edu");
-          cy.get(".coordinator-email-input-submit").click();
+      cy.get(".coordinator-add-student-modal").within(() => {
+        cy.get(".coordinator-email-input").type("testuser1@berkeley.edu");
+        cy.get(".coordinator-email-input-submit").click();
 
-          // wait for request; should fail
-          cy.wait("@add-student").its("response.statusCode").should("eq", 422);
+        // wait for request; should fail
+        cy.wait("@add-student").its("response.statusCode").should("eq", 422);
 
-          cy.contains(".coordinator-email-response-capacity-container", /section capacity exceeded/i).within(() => {
-            // should display capacity exceeded
-            cy.contains(".coordinator-email-response-capacity", /section capacity exceeded/i).should("be.visible");
+        cy.contains(".coordinator-email-response-capacity-container", /section capacity exceeded/i).within(() => {
+          // should display capacity exceeded
+          cy.contains(".coordinator-email-response-capacity", /section capacity exceeded/i).should("be.visible");
 
-            cy.get("input[type='radio'][value='EXPAND']").click();
-          });
+          cy.get("input[type='radio'][value='EXPAND']").click();
+        });
 
-          cy.contains(".coordinator-email-input-submit", /retry/i).click();
-          cy.wait("@add-student").its("response.statusCode").should("eq", 200);
-        })
-        .should("not.exist");
+        cy.contains(".coordinator-email-input-submit", /retry/i).click();
+        cy.wait("@add-student").its("response.statusCode").should("eq", 200);
+      });
+
+      cy.get(".coordinator-add-student-modal").should("not.exist");
 
       cy.wait("@section-students");
 
@@ -355,91 +355,91 @@ describe("modifying students", () => {
       cy.wait("@section-students");
       cy.get(".coordinator-email-modal-button").click();
 
-      cy.get(".coordinator-add-student-modal")
-        .within(() => {
-          // valid user
-          cy.get(".coordinator-email-input").last().type("testuser1@berkeley.edu");
-          cy.contains(".coordinator-email-input-add", /add email/i)
-            .focus()
-            .click();
-          // mentor for another section
-          cy.get(".coordinator-email-input").last().type("user1@berkeley.edu");
-          cy.contains(".coordinator-email-input-add", /add email/i).click();
+      cy.get(".coordinator-add-student-modal").within(() => {
+        // valid user
+        cy.get(".coordinator-email-input").last().type("testuser1@berkeley.edu");
+        cy.contains(".coordinator-email-input-add", /add email/i)
+          .focus()
+          .click();
+        // mentor for another section
+        cy.get(".coordinator-email-input").last().type("user1@berkeley.edu");
+        cy.contains(".coordinator-email-input-add", /add email/i).click();
+        // conflicting section
+        cy.get(".coordinator-email-input").last().type("user2@berkeley.edu");
+        cy.contains(".coordinator-email-input-add", /add email/i).click();
+        // banned user
+        cy.get(".coordinator-email-input").last().type("banned_student@berkeley.edu");
+
+        // submit and wait for request; should fail
+        cy.get(".coordinator-email-input-submit").click();
+        cy.wait("@add-student").its("response.statusCode").should("eq", 422);
+
+        cy.contains(".coordinator-email-response-container", /section conflict/i).within(() => {
+          // should display section conflict
+          cy.contains(".coordinator-email-response-status-conflict", /section conflict/i).should("be.visible");
+
           // conflicting section
-          cy.get(".coordinator-email-input").last().type("user2@berkeley.edu");
-          cy.contains(".coordinator-email-input-add", /add email/i).click();
-          // banned user
-          cy.get(".coordinator-email-input").last().type("banned_student@berkeley.edu");
+          cy.contains(".coordinator-email-response-item", "user1@berkeley.edu").within(() => {
+            // check text objects
+            cy.contains("span", "user1@berkeley.edu").should("be.visible");
+            cy.contains("div", /User is already a mentor for the course/i).should("be.visible");
+            cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("be.disabled");
 
-          // submit and wait for request; should fail
-          cy.get(".coordinator-email-input-submit").click();
-          cy.wait("@add-student").its("response.statusCode").should("eq", 422);
-
-          cy.contains(".coordinator-email-response-container", /section conflict/i).within(() => {
-            // should display section conflict
-            cy.contains(".coordinator-email-response-status-conflict", /section conflict/i).should("be.visible");
-
-            // conflicting section
-            cy.contains(".coordinator-email-response-item", "user1@berkeley.edu").within(() => {
-              // check text objects
-              cy.contains("span", "user1@berkeley.edu").should("be.visible");
-              cy.contains("div", /User is already a mentor for the course/i).should("be.visible");
-              cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("be.disabled");
-
-              // remove email
-              cy.get("span.inline-plus-sign").click().should("not.exist");
-            });
-
-            // mentor for another section
-            cy.contains(".coordinator-email-response-item", "user2@berkeley.edu").within(() => {
-              // get actual text object
-              cy.contains("span", "user2@berkeley.edu").should("be.visible");
-              // check conflicting section link
-              cy.contains("div", /conflict: user one/i)
-                .should("be.visible")
-                .find("a")
-                .invoke("attr", "href")
-                .should("eq", "/sections/2");
-
-              // drop student from other section
-              cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("not.be.disabled").click();
-            });
+            // remove email
+            cy.get("span.inline-plus-sign").click().should("not.exist");
           });
 
-          cy.contains(".coordinator-email-response-container", /student banned/i).within(() => {
-            // should display section conflict
-            cy.contains(".coordinator-email-response-status-banned", /student banned/i).should("be.visible");
+          // mentor for another section
+          cy.contains(".coordinator-email-response-item", "user2@berkeley.edu").within(() => {
+            // get actual text object
+            cy.contains("span", "user2@berkeley.edu").should("be.visible");
+            // check conflicting section link
+            cy.contains("div", /conflict: user one/i)
+              .should("be.visible")
+              .find("a")
+              .invoke("attr", "href")
+              .should("eq", "/sections/2");
 
-            cy.contains(".coordinator-email-response-item", "banned_student@berkeley.edu").within(() => {
-              // get actual text object
-              cy.contains("span", "banned_student@berkeley.edu").should("be.visible");
-              // unban and enroll student
-              cy.get("input[type='radio'][value='UNBAN_ENROLL']")
-                .should("have.length", 1)
-                .should("not.be.disabled")
-                .click();
-            });
+            // drop student from other section
+            cy.get("input[type='checkbox'][value='DROP']").should("have.length", 1).should("not.be.disabled").click();
           });
+        });
 
-          // valid user
-          cy.contains(".coordinator-email-response-container", /ok/i).within(() => {
-            cy.contains(".coordinator-email-response-status-ok", /ok/i).should("be.visible");
-            // not visible but should have visible text
-            cy.contains(".coordinator-email-response-item span", "testuser1@berkeley.edu").should("exist");
+        cy.contains(".coordinator-email-response-container", /student banned/i).within(() => {
+          // should display section conflict
+          cy.contains(".coordinator-email-response-status-banned", /student banned/i).should("be.visible");
+
+          cy.contains(".coordinator-email-response-item", "banned_student@berkeley.edu").within(() => {
+            // get actual text object
+            cy.contains("span", "banned_student@berkeley.edu").should("be.visible");
+            // unban and enroll student
+            cy.get("input[type='radio'][value='UNBAN_ENROLL']")
+              .should("have.length", 1)
+              .should("not.be.disabled")
+              .click();
           });
+        });
 
-          cy.contains(".coordinator-email-response-capacity-container", /section capacity exceeded/i).within(() => {
-            // should display capacity exceeded
-            cy.contains(".coordinator-email-response-capacity", /section capacity exceeded/i).should("be.visible");
+        // valid user
+        cy.contains(".coordinator-email-response-container", /ok/i).within(() => {
+          cy.contains(".coordinator-email-response-status-ok", /ok/i).should("be.visible");
+          // not visible but should have visible text
+          cy.contains(".coordinator-email-response-item span", "testuser1@berkeley.edu").should("exist");
+        });
 
-            cy.get("input[type='radio'][value='EXPAND']").click();
-          });
+        cy.contains(".coordinator-email-response-capacity-container", /section capacity exceeded/i).within(() => {
+          // should display capacity exceeded
+          cy.contains(".coordinator-email-response-capacity", /section capacity exceeded/i).should("be.visible");
 
-          // submit form
-          cy.get(".coordinator-email-input-submit").click();
-          cy.wait("@add-student");
-        })
-        .should("not.exist");
+          cy.get("input[type='radio'][value='EXPAND']").click();
+        });
+
+        // submit form
+        cy.get(".coordinator-email-input-submit").click();
+        cy.wait("@add-student");
+      });
+
+      cy.get(".coordinator-add-student-modal").should("not.exist");
 
       cy.wait("@section-students");
 

--- a/cypress/e2e/section/mentor-section.cy.ts
+++ b/cypress/e2e/section/mentor-section.cy.ts
@@ -100,9 +100,10 @@ describe("attendances", () => {
       .should("have.length", 2)
       // click second (inactive) tab
       .last()
-      .should("not.have.class", "active")
-      .click()
-      .should("have.class", "active");
+      .then($tab => {
+        cy.wrap($tab).should("not.have.class", "active").click();
+        cy.wrap($tab).should("have.class", "active");
+      });
 
     // attendances in the second tab should all be present
     cy.get("#mentor-attendance-table select")
@@ -284,10 +285,10 @@ describe("word of the day", () => {
     });
 
     // go to next day and should be unselected
-    cy.get("#attendance-date-tabs-container > :not(.active)")
-      .should("have.length", 1)
-      .click()
-      .should("have.class", "active");
+    cy.get("#attendance-date-tabs-container > :not(.active)").then($tab => {
+      cy.wrap($tab).should("have.length", 1).click();
+      cy.wrap($tab).should("have.class", "active");
+    });
 
     cy.get("#word-of-the-day-container").within(() => {
       cy.contains(".word-of-the-day-title", /word of the day/i).should("be.visible");
@@ -299,10 +300,10 @@ describe("word of the day", () => {
     });
 
     // switch back and it should be selected again
-    cy.get("#attendance-date-tabs-container > :not(.active)")
-      .should("have.length", 1)
-      .click()
-      .should("have.class", "active");
+    cy.get("#attendance-date-tabs-container > :not(.active)").then($tab => {
+      cy.wrap($tab).should("have.length", 1).click();
+      cy.wrap($tab).should("have.class", "active");
+    });
 
     cy.get("#word-of-the-day-container").within(() => {
       cy.contains(".word-of-the-day-title", /word of the day/i).should("be.visible");


### PR DESCRIPTION
See https://docs.cypress.io/guides/core-concepts/retry-ability#Only-queries-are-retried.

Existing tests have used `.click().should(...)` to assert for changes after an action, which does not retry the assertion; this means that the corresponding tests are very flaky, especially when state changes across several re-renderings.