### PR TITLE
Optimize test data creation

### DIFF
--- a/csm_web/scheduler/tests/utils.py
+++ b/csm_web/scheduler/tests/utils.py
@@ -7,7 +7,6 @@ from scheduler.factories import (
     UserFactory,
     StudentFactory,
     SectionFactory,
-    create_attendances_for,
 )
 
 COURSE_NAMES = ("CS88", "CS61A", "CS61B", "CS70", "CS61C", "EE16A", "EE16B")


### PR DESCRIPTION
Currently, running `createtestdata` takes about a minute to finish, which is quite a long time to wait when not very many objects are being created.

Some optimizations that have been made:
- Use `Factory.build` as much as possible, rather than using `Factory.create`, so that we can save all the instances at once with `bulk_create`. This requires a bit of shuffling around to get dependencies created correctly, especially since running `bulk_create` does not create related objects (ex. foreign key instances created by subfactories).
- Use `select_related` and `prefetch_related` in loops after creation, to avoid large amounts of queries in loops.

Additionally, the `factories.py` file has been reformatted along with these changes. In the future, we can do similar kinds of optimizations (as with #278) for other views.