### PR TITLE
Fix restricted courses admin, add word of the day to admin

### DIFF
--- a/csm_web/scheduler/admin.py
+++ b/csm_web/scheduler/admin.py
@@ -450,7 +450,7 @@ class CourseAdmin(CoordAdmin):
             "number_of_students",
             "number_of_mentors",
         )
-        if obj.is_restricted:
+        if obj is not None and obj.is_restricted:
             all_fields += ("whitelist",)
         return all_fields
 
@@ -533,10 +533,10 @@ class DayEndFilter(admin.SimpleListFilter):
 
 @admin.register(SectionOccurrence)
 class SectionOccurrenceAdmin(CoordAdmin):
-    fields = ("section", "date")
-    list_display = ("id", "section", "date")
+    fields = ("section", "date", "word_of_the_day")
+    list_display = ("id", "section", "date", "word_of_the_day")
     list_filter = ("date",)
-    search_fields = ("section__mentor__user__first_name", "section__mentor__user__last_name", "date")
+    search_fields = ("section__mentor__user__first_name", "section__mentor__user__last_name", "date", "word_of_the_day")
 
 
 @admin.register(Attendance)


### PR DESCRIPTION
Quick PR for a fix to adding courses through the admin menu; it's currently broken on prod, but not an urgent issue (hence not a hotfix), though a timely merge would be beneficial.

Additionally, word of the day has been added to the admin menu, so we can view and edit individual word of the days for section occurrences.