### PR TITLE
Hotfix: Errors when no attendances, Optimize courses endpoint

### DIFF
--- a/csm_web/frontend/src/components/section/MentorSectionAttendance.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionAttendance.tsx
@@ -104,13 +104,17 @@ const MentorSectionAttendance = ({ sectionId }: MentorSectionAttendanceProps): R
       setOccurrenceMap(newOccurrenceMap);
       setSortedOccurrences(newSortedOccurrences);
 
+      let newAttendances = null;
       if (selectedOccurrence === null) {
         // only update selected occurrence if it has not been set before
         setSelectedOcurrence(newSortedOccurrences[0]);
-        setStagedAttendances(newOccurrenceMap.get(newSortedOccurrences[0].id)!.attendances);
+        newAttendances = newOccurrenceMap.get(newSortedOccurrences[0]?.id)?.attendances;
       } else {
         // otherwise use existing selectedOccurrence
-        setStagedAttendances(newOccurrenceMap.get(selectedOccurrence.id)!.attendances);
+        newAttendances = newOccurrenceMap.get(selectedOccurrence.id)!.attendances;
+      }
+      if (newAttendances) {
+        setStagedAttendances(newAttendances);
       }
     }
   }, [jsonAttendances]);

--- a/csm_web/scheduler/management/commands/create_attendances.py
+++ b/csm_web/scheduler/management/commands/create_attendances.py
@@ -28,6 +28,11 @@ class Command(BaseCommand):
                     "section": section} for section in sections for spacetime in section.spacetimes.all()]
             sos_models = []  # list of section occurrence models
             for so in sos:
+                section = so["section"]
+                date = so["date"]
+                if date < section.mentor.course.section_start:
+                    # skip section occurrence if it's before section start date
+                    continue
                 try:
                     cur, _ = SectionOccurrence.objects.get_or_create(**so)
                     sos_models.append(cur)

--- a/csm_web/scheduler/views/course.py
+++ b/csm_web/scheduler/views/course.py
@@ -29,25 +29,19 @@ class CourseViewSet(*viewset_with("list")):
             "section__mentor__course__id", flat=True
         )
         now = timezone.now().astimezone(timezone.get_default_timezone())
-        return (
-            Course.objects.exclude(pk__in=banned_from)
-            .order_by("name")
-            .filter(
-                Q(valid_until__gte=now.date()) | Q(coordinator__user=self.request.user)
-            )
-            .filter(
-                # allow unrestricted or if associated
-                (
-                    Q(is_restricted=False)
-                    | Q(coordinator__user=self.request.user)
-                    | Q(mentor__user=self.request.user)
-                    | Q(student__user=self.request.user)
-                )
-                # filter out restricted courses
-                | (Q(is_restricted=True) & Q(whitelist=self.request.user))
-            )
-            .distinct()
-        )
+        unrestricted_courses = set(Course.objects.filter(is_restricted=False).values_list('pk', flat=True))
+        user = self.request.user
+        user_coords = set(user.coordinator_set.values_list('course__pk', flat=True))
+        user_mentors = set(user.mentor_set.values_list('course__pk', flat=True))
+        user_students = set(user.student_set.values_list('course__pk', flat=True))
+        user_whitelist = set(user.whitelist.values_list('pk', flat=True))
+        # mentor/student/whitelist/unrestricted all have restriction of valid_until
+        course_pks_filter_valid = user_mentors | user_students | user_whitelist | unrestricted_courses
+        valid_courses = Course.objects.filter(pk__in=course_pks_filter_valid, valid_until__gte=now.date())
+        # coord can still see invalid courses
+        coord_courses = Course.objects.exclude(pk__in=banned_from).filter(pk__in=user_coords)
+
+        return (valid_courses | coord_courses).distinct().order_by('name')
 
     def get_sections_by_day(self, course):
         """Get a course's sections, grouped by the days the section occurs."""


### PR DESCRIPTION
This is a PR for several hotfixes for the prod release of CS70 sections:
* There was an existing frontend issue that does not allow users to view attendances if no attendances exist.
* Additionally, some minor adjustments were made to attendance creation commands/views for edge cases.
* The courses endpoint was extremely slow, retrieving a query of over 5 million objects (before the `.distinct()` modifier) when really only around 7 courses are possible. This was optimized and rewritten with more queries but for fewer objects.