### PR TITLE
Prevent mentors from submitting less than 3 nonzero preferences

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
@@ -7,6 +7,7 @@ import { Slot } from "./EnrollmentAutomationTypes";
 import { formatInterval, formatTime, MAX_PREFERENCE, parseTime } from "./utils";
 
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
+import ErrorCircle from "../../../static/frontend/img/x_circle.svg";
 import { useMatcherPreferenceMutation, useMatcherPreferences, useMatcherSlots } from "../../utils/queries/matcher";
 
 enum Status {
@@ -203,6 +204,9 @@ export function MentorSectionPreferences({
           <div className="matcher-sidebar-pref-help">
             Rate your preferences from 0 to {MAX_PREFERENCE}.
             <br />0 means unavailable, {MAX_PREFERENCE} means most preferred.
+            <br />
+            <br />
+            <b>Please provide nonzero preferences for at least 3 slots.</b>
           </div>
           <div>Shift-click to select more slots.</div>
         </div>
@@ -217,6 +221,10 @@ export function MentorSectionPreferences({
       break;
     case Status.SUCCESS:
       statusContent = <CheckCircle className="icon matcher-submit-status-icon" />;
+      break;
+    case Status.ERROR:
+      statusContent = <ErrorCircle className="icon matcher-submit-status-icon error error" />;
+      break;
   }
 
   return (

--- a/csm_web/frontend/src/utils/queries/matcher.tsx
+++ b/csm_web/frontend/src/utils/queries/matcher.tsx
@@ -209,6 +209,8 @@ export const useMatcherPreferenceMutation = (
       const response = await fetchWithMethod(`/matcher/${courseId}/preferences`, HTTP_METHODS.POST, body);
       if (!response.ok && response.status === 500) {
         throw new ServerError(`Failed to update matcher preferences for course ${courseId}`);
+      } else if (!response.ok && response.status >= 400 && response.status < 500) {
+        throw new PermissionError("Permission denied");
       }
       return response.ok;
     },

--- a/csm_web/frontend/static/frontend/css/enrollment_matcher.css
+++ b/csm_web/frontend/static/frontend/css/enrollment_matcher.css
@@ -163,6 +163,10 @@
 	height: 1.5em !important;
 }
 
+.matcher-submit-status-icon.error {
+	color: var(--csm-danger);
+}
+
 .matcher-detail-time {
 	font-size: 0.9rem;
 }

--- a/csm_web/scheduler/views/matcher.py
+++ b/csm_web/scheduler/views/matcher.py
@@ -229,6 +229,10 @@ def preferences(request, pk=None):
         mentor = Mentor.objects.get(
             user=request.user, course=course, section__isnull=True
         )
+
+        if len([pref for pref in request.data if pref["preference"] > 0]) < 3:
+            raise PermissionDenied("Less than 3 nonzero preferences provided.")
+
         for pref in request.data:
             curslot = MatcherSlot.objects.get(pk=pref["id"])
             existing_queryset = MatcherPreference.objects.filter(


### PR DESCRIPTION
Resolves #333.

Fixes the matcher exploit by posing a hard restriction on the number of nonzero preferences a mentor can submit. Currently, this is a hard-coded limit of 3 slots, but in the future, this should be configurable by the coordinator.