### PR TITLE
Update dependencies from dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12377,9 +12377,9 @@
       }
     },
     "node_modules/loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
@@ -24624,9 +24624,9 @@
       "dev": true
     },
     "loader-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-      "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
       "dev": true,
       "requires": {
         "big.js": "^5.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12225,9 +12225,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -12391,9 +12391,9 @@
       }
     },
     "node_modules/loader-utils/node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -24516,9 +24516,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsonfile": {
@@ -24635,9 +24635,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "random-words": "^1.1.2",
         "style-loader": "^3.2.1",
         "typescript": "^4.8.4",
-        "webpack": "^5.73.0",
+        "webpack": "^5.76.0",
         "webpack-cli": "^4.10.0"
       }
     },
@@ -14969,9 +14969,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -26545,9 +26545,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.74.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
-      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.0.tgz",
+      "integrity": "sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "random-words": "^1.1.2",
     "style-loader": "^3.2.1",
     "typescript": "^4.8.4",
-    "webpack": "^5.73.0",
+    "webpack": "^5.76.0",
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ asgiref==3.4.1
 boto3==1.18.32
 botocore==1.21.32
 Brotli==1.0.9
-certifi==2021.5.30
+certifi==2022.12.7
 cffi==1.14.6
 chardet==4.0.0
 charset-normalizer==2.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ cffi==1.14.6
 chardet==4.0.0
 charset-normalizer==2.0.4
 colorama==0.4.4
-cryptography==3.4.8
+cryptography==39.0.1
 defusedxml==0.7.1
 dj-database-url==0.5.0
 Django==3.2.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,6 @@ social-auth-app-django==5.0.0
 social-auth-core==4.1.0
 sqlparse==0.4.4
 text-unidecode==1.3
-urllib3==1.26.6
+urllib3==1.26.11
 whitenoise==5.3.0
 wrapt==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ colorama==0.4.4
 cryptography==3.4.8
 defusedxml==0.7.1
 dj-database-url==0.5.0
-Django==3.2.16
+Django==3.2.17
 django-csp==3.7
 django-extensions==3.1.3
 django-heroku==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ PyYAML==5.4.1
 requests==2.31.0
 requests-oauthlib==1.3.0
 s3transfer==0.5.0
-sentry-sdk==1.3.1
+sentry-sdk==1.14.0
 six==1.16.0
 social-auth-app-django==5.0.0
 social-auth-core==4.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ sentry-sdk==1.14.0
 six==1.16.0
 social-auth-app-django==5.0.0
 social-auth-core==4.1.0
-sqlparse==0.4.2
+sqlparse==0.4.4
 text-unidecode==1.3
 urllib3==1.26.6
 whitenoise==5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ colorama==0.4.4
 cryptography==39.0.1
 defusedxml==0.7.1
 dj-database-url==0.5.0
-Django==3.2.17
+Django==3.2.18
 django-csp==3.7
 django-extensions==3.1.3
 django-heroku==0.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ gunicorn==20.1.0
 idna==3.2
 jmespath==0.10.0
 networkx==2.8.3
-oauthlib==3.2.1
+oauthlib==3.2.2
 psycopg2==2.9.1
 psycopg2-binary==2.9.1
 pycparser==2.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ python-social-auth==0.3.6
 python3-openid==3.2.0
 pytz==2021.1
 PyYAML==5.4.1
-requests==2.26.0
+requests==2.31.0
 requests-oauthlib==1.3.0
 s3transfer==0.5.0
 sentry-sdk==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ colorama==0.4.4
 cryptography==39.0.1
 defusedxml==0.7.1
 dj-database-url==0.5.0
-Django==3.2.18
+Django==3.2.19
 django-csp==3.7
 django-extensions==3.1.3
 django-heroku==0.3.1


### PR DESCRIPTION
Dependabot automatic PRs tend to fail CIs because of insufficient secret access, so this PR will aggregate several pending dependabot updates.

Dependabot PRs aggregated:
* #355 
* #362 
* #365 
* #386 
* #387 
* #388
* #392
* #403
* #405
* #409
* #410
* #414
* #416

Additionally, a manual upgrade of `urllib3` from `1.26.6` to `1.26.11` was done due to dependency conflicts.