### PR TITLE
Fix export attendance script

### DIFF
--- a/csm_web/scheduler/management/commands/export_attendances.py
+++ b/csm_web/scheduler/management/commands/export_attendances.py
@@ -1,6 +1,7 @@
 import csv
+
 from django.core.management import BaseCommand
-from scheduler.models import Course, Attendance
+from scheduler.models import Attendance, Course
 
 
 class Command(BaseCommand):
@@ -18,34 +19,43 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.csvwriter = csv.writer(self.stdout, dialect='unix', quoting=csv.QUOTE_MINIMAL)
+        self.csvwriter = csv.writer(
+            self.stdout, dialect="unix", quoting=csv.QUOTE_MINIMAL
+        )
 
     def add_arguments(self, parser):
         parser.add_argument("course", type=str, help="the name of the course")
 
     def handle(self, *args, **options):
         course = Course.objects.get(name=options["course"].upper())
-        attendances = Attendance.objects.filter(student__active=True, student__section__course=course).select_related(
-            'student__user', 'student__section__mentor').prefetch_related(
-            'student__section__spacetimes').order_by("student__pk", "student__section__spacetimes__day_of_week",
-                                                     "student__section__spacetimes__start_time",
-                                                     "student__section__mentor")
+        attendances = (
+            Attendance.objects.filter(student__active=True, student__course=course)
+            .select_related(
+                "student__user", "student__section__mentor", "sectionOccurrence"
+            )
+            .prefetch_related("student__section__spacetimes")
+            .order_by(
+                "student__pk",
+                "sectionOccurrence__date",
+                "student__section__mentor",
+            )
+        )
         # Write headers
         self._write(self.COLS)
         for attendance in attendances:
             student = attendance.student
             section = student.section
             mentor = section.mentor
-            spacetimes = list(section.spacetimes.all())
+            spacetimes = list(section.spacetimes.all().order_by('day_of_week', 'start_time'))
             row = (
                 student.user.get_full_name(),
                 student.user.email,
-                str(attendance.date),
+                str(attendance.sectionOccurrence.date),
                 attendance.get_presence_display(),
                 mentor.user.get_full_name(),
                 mentor.user.email,
-                '|'.join(s.day_of_week for s in spacetimes),
-                '|'.join(str(s.start_time) for s in spacetimes),
+                "|".join(s.day_of_week for s in spacetimes),
+                "|".join(str(s.start_time) for s in spacetimes),
             )
             self._write(row)
 


### PR DESCRIPTION
The current `export_attendances` command uses an old version of the attendance model, without section occurrences. It also had an issue where exported attendances would be duplicated (due to an inner join in selecting spacetime objects for ordering), and this has been fixed as well. The file was also reformatted via `black`.