### PR TITLE
Add `workflow_dispatch` trigger to all actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: 3.9

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: 3.9

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,6 +8,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 env:
   NODE_VERSION: 16.x

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   push:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
Since the current GitHub actions are triggered by push and PR events on the master branch, any PRs or pushes to other branches do not trigger any workflows, and also cannot be manually triggered either. In case we'd like to run any CI actions on these extraneous branches, adding the `workflow_dispatch` trigger can be helpful, as it allows us to manually trigger workflows from the Actions tab: https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow.