### PR TITLE
Add Luxon, refactor date parsing/formatting

### DIFF
--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -35,7 +35,7 @@ const CourseMenu = () => {
   if (userInfoLoaded) {
     let priorityEnrollment = undefined;
     if (jsonUserInfo.priorityEnrollment) {
-      priorityEnrollment = DateTime.fromISO(jsonUserInfo.priorityEnrollment);
+      priorityEnrollment = DateTime.fromISO(jsonUserInfo.priorityEnrollment, { zone: DEFAULT_TIMEZONE });
     }
     const convertedUserInfo: UserInfo = {
       ...jsonUserInfo,

--- a/csm_web/frontend/src/components/CourseMenu.tsx
+++ b/csm_web/frontend/src/components/CourseMenu.tsx
@@ -5,6 +5,8 @@ import { useUserInfo } from "../utils/queries/base";
 import { Course as CourseType, UserInfo } from "../utils/types";
 import Course from "./course/Course";
 import LoadingSpinner from "./LoadingSpinner";
+import { DateTime } from "luxon";
+import { DEFAULT_LONG_LOCALE_OPTIONS, DEFAULT_TIMEZONE } from "../utils/datetime";
 
 const CourseMenu = () => {
   const { data: jsonCourses, isSuccess: coursesLoaded } = useCourses();
@@ -33,7 +35,7 @@ const CourseMenu = () => {
   if (userInfoLoaded) {
     let priorityEnrollment = undefined;
     if (jsonUserInfo.priorityEnrollment) {
-      priorityEnrollment = new Date(Date.parse(jsonUserInfo.priorityEnrollment));
+      priorityEnrollment = DateTime.fromISO(jsonUserInfo.priorityEnrollment);
     }
     const convertedUserInfo: UserInfo = {
       ...jsonUserInfo,
@@ -46,7 +48,7 @@ const CourseMenu = () => {
   }
 
   let show_enrollment_times = false;
-  const enrollment_times_by_course: Array<{ courseName: string; enrollmentDate: Date }> = [];
+  const enrollment_times_by_course: Array<{ courseName: string; enrollmentDate: DateTime }> = [];
 
   if (courses !== null) {
     for (const course of courses.values()) {
@@ -54,7 +56,7 @@ const CourseMenu = () => {
       if (!course.enrollmentOpen) {
         enrollment_times_by_course.push({
           courseName: course.name,
-          enrollmentDate: new Date(Date.parse(course.enrollmentStart))
+          enrollmentDate: DateTime.fromISO(course.enrollmentStart, { zone: DEFAULT_TIMEZONE })
         });
       }
     }
@@ -97,7 +99,7 @@ interface CourseMenuContentProps {
   courses: Map<number, CourseType> | null;
   coursesLoaded: boolean;
   userInfo: UserInfo | null;
-  enrollment_times_by_course: Array<{ courseName: string; enrollmentDate: Date }>;
+  enrollment_times_by_course: Array<{ courseName: string; enrollmentDate: DateTime }>;
 }
 
 enum CourseMenuSidebarTabs {
@@ -217,7 +219,7 @@ const EnrollmentMenu = ({ courses }: EnrollmentMenuProps) => {
 interface EnrollmentTimesProps {
   coursesLoaded: boolean;
   userInfo: UserInfo | null;
-  enrollmentTimes: Array<{ courseName: string; enrollmentDate: Date }>;
+  enrollmentTimes: Array<{ courseName: string; enrollmentDate: DateTime }>;
 }
 
 /**
@@ -237,19 +239,6 @@ const EnrollmentTimes = ({
     return null;
   }
 
-  /**
-   * Formatting for the enrollment times.
-   */
-  const date_locale_string_options: Intl.DateTimeFormatOptions = {
-    weekday: "long",
-    month: "numeric",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    hour12: true,
-    timeZoneName: "short"
-  };
-
   if (enrollmentTimes.length === 0) {
     return null;
   }
@@ -266,16 +255,14 @@ const EnrollmentTimes = ({
                 <em>Priority</em>
               </div>
               <div className="enrollment-time">
-                <em>{`${userInfo.priorityEnrollment.toLocaleDateString("en-US", date_locale_string_options)}`}</em>
+                <em>{`${userInfo.priorityEnrollment.toLocaleString(DEFAULT_LONG_LOCALE_OPTIONS)}`}</em>
               </div>
             </div>
           )}
           {enrollmentTimes.map(({ courseName, enrollmentDate }) => (
             <div className="enrollment-row" key={courseName}>
               <div className="enrollment-course">{courseName}</div>
-              <div className="enrollment-time">
-                {`${enrollmentDate.toLocaleDateString("en-US", date_locale_string_options)}`}
-              </div>
+              <div className="enrollment-time">{`${enrollmentDate.toLocaleString(DEFAULT_LONG_LOCALE_OPTIONS)}`}</div>
             </div>
           ))}
         </div>

--- a/csm_web/frontend/src/components/Home.tsx
+++ b/csm_web/frontend/src/components/Home.tsx
@@ -6,6 +6,7 @@ import { useCourses } from "../utils/queries/courses";
 import { ROLES } from "./section/Section";
 import { Profile, Course } from "../utils/types";
 import LoadingSpinner from "./LoadingSpinner";
+import { formatSpacetimeInterval } from "../utils/datetime";
 
 const Home = () => {
   const { data: profiles, isSuccess: profilesLoaded, isError: profilesLoadError } = useProfiles();
@@ -91,7 +92,7 @@ const CourseCard = ({ profiles }: CourseCardProps): React.ReactElement => {
               <Link key={profile.id} to={`/sections/${profile.sectionId}`} className="section-link">
                 {profile.sectionSpacetimes.map(spacetime => (
                   <div key={spacetime.id} className="course-card-section-time">
-                    {spacetime.time}
+                    {formatSpacetimeInterval(spacetime)}
                   </div>
                 ))}
               </Link>

--- a/csm_web/frontend/src/components/course/Course.tsx
+++ b/csm_web/frontend/src/components/course/Course.tsx
@@ -10,6 +10,8 @@ import { WhitelistModal } from "./WhitelistModal";
 import { SettingsModal } from "./SettingsModal";
 
 import PencilIcon from "../../../static/frontend/img/pencil.svg";
+import { DateTime } from "luxon";
+import { DEFAULT_LONG_LOCALE_OPTIONS } from "../../utils/datetime";
 
 const DAY_OF_WEEK_ABREVIATIONS: { [day: string]: string } = Object.freeze({
   Monday: "M",
@@ -35,8 +37,8 @@ interface CourseProps {
    * CourseMenu is done with its API requests, making the user suffer twice the latency for no reason.
    */
   courses: Map<number, CourseType> | null;
-  enrollmentTimes: Array<{ courseName: string; enrollmentDate: Date }>;
-  priorityEnrollment: Date | undefined;
+  enrollmentTimes: Array<{ courseName: string; enrollmentDate: DateTime }>;
+  priorityEnrollment: DateTime | undefined;
 }
 
 const Course = ({ courses, priorityEnrollment, enrollmentTimes }: CourseProps): React.ReactElement | null => {
@@ -118,20 +120,9 @@ const Course = ({ courses, priorityEnrollment, enrollmentTimes }: CourseProps): 
     currDaySections = currDaySections.filter(({ numStudentsEnrolled, capacity }) => numStudentsEnrolled < capacity);
   }
 
-  // copied from CourseMenu.tsx
-  const date_locale_string_options: Intl.DateTimeFormatOptions = {
-    weekday: "long",
-    month: "numeric",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-    hour12: true,
-    timeZoneName: "short"
-  };
-
   const enrollmentDate =
     priorityEnrollment ?? enrollmentTimes.find(({ courseName }) => courseName == course.name)?.enrollmentDate;
-  const enrollmentTimeString = enrollmentDate?.toLocaleDateString("en-US", date_locale_string_options) ?? "";
+  const enrollmentTimeString = enrollmentDate?.toLocaleString(DEFAULT_LONG_LOCALE_OPTIONS) ?? "";
 
   return (
     <div id="course-section-selector">

--- a/csm_web/frontend/src/components/course/Course.tsx
+++ b/csm_web/frontend/src/components/course/Course.tsx
@@ -1,3 +1,4 @@
+import { DateTime } from "luxon";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useCourseSections } from "../../utils/queries/courses";
@@ -8,10 +9,9 @@ import { DataExportModal } from "./DataExportModal";
 import { SectionCard } from "./SectionCard";
 import { WhitelistModal } from "./WhitelistModal";
 import { SettingsModal } from "./SettingsModal";
+import { DEFAULT_LONG_LOCALE_OPTIONS } from "../../utils/datetime";
 
 import PencilIcon from "../../../static/frontend/img/pencil.svg";
-import { DateTime } from "luxon";
-import { DEFAULT_LONG_LOCALE_OPTIONS } from "../../utils/datetime";
 
 const DAY_OF_WEEK_ABREVIATIONS: { [day: string]: string } = Object.freeze({
   Monday: "M",

--- a/csm_web/frontend/src/components/course/SectionCard.tsx
+++ b/csm_web/frontend/src/components/course/SectionCard.tsx
@@ -11,6 +11,7 @@ import GroupIcon from "../../../static/frontend/img/group.svg";
 import LocationIcon from "../../../static/frontend/img/location.svg";
 import UserIcon from "../../../static/frontend/img/user.svg";
 import XCircle from "../../../static/frontend/img/x_circle.svg";
+import { formatSpacetimeInterval } from "../../utils/datetime";
 
 interface SectionCardProps {
   id: number;
@@ -151,16 +152,16 @@ export const SectionCard = ({
             )}
           </p>
           <p title="Time">
-            <ClockIcon width={iconWidth} height={iconHeight} /> {spacetimes[0].time}
+            <ClockIcon width={iconWidth} height={iconHeight} /> {formatSpacetimeInterval(spacetimes[0])}
             {spacetimes.length > 1 && (
               <span className="section-card-additional-times">
-                {spacetimes.slice(1).map(({ time, id }) => (
-                  <React.Fragment key={id}>
+                {spacetimes.slice(1).map(spacetime => (
+                  <React.Fragment key={spacetime.id}>
                     <span
                       className="section-card-icon-placeholder"
                       style={{ minWidth: iconWidth, minHeight: iconHeight }}
                     />{" "}
-                    {time}
+                    {formatSpacetimeInterval(spacetime)}
                   </React.Fragment>
                 ))}
               </span>

--- a/csm_web/frontend/src/components/enrollment_automation/EnrollmentAutomationTypes.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/EnrollmentAutomationTypes.tsx
@@ -1,7 +1,8 @@
+import { Interval } from "luxon";
+
 export interface Time {
   day: string;
-  startTime: number;
-  endTime: number;
+  interval: Interval;
   isLinked: boolean;
 }
 

--- a/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/MentorSectionPreferences.tsx
@@ -1,14 +1,17 @@
+import { Interval } from "luxon";
 import React, { useEffect, useState } from "react";
+
 import { Profile } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
 import { Calendar } from "./calendar/Calendar";
 import { CalendarEvent, CalendarEventSingleTime } from "./calendar/CalendarTypes";
 import { Slot } from "./EnrollmentAutomationTypes";
-import { formatInterval, formatTime, MAX_PREFERENCE, parseTime } from "./utils";
+import { MAX_PREFERENCE, parseTime } from "./utils";
+import { useMatcherPreferenceMutation, useMatcherPreferences, useMatcherSlots } from "../../utils/queries/matcher";
+import { formatInterval } from "../../utils/datetime";
 
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
 import ErrorCircle from "../../../static/frontend/img/x_circle.svg";
-import { useMatcherPreferenceMutation, useMatcherPreferences, useMatcherSlots } from "../../utils/queries/matcher";
 
 enum Status {
   NONE,
@@ -56,8 +59,7 @@ export function MentorSectionPreferences({
       for (const time of slot.times) {
         times.push({
           day: time.day,
-          startTime: parseTime(time.startTime),
-          endTime: parseTime(time.endTime),
+          interval: Interval.fromDateTimes(parseTime(time.startTime), parseTime(time.endTime)),
           isLinked: time.isLinked
         });
       }
@@ -153,7 +155,7 @@ export function MentorSectionPreferences({
 
     return (
       <React.Fragment>
-        <span className="calendar-event-detail-time">{formatInterval(event.time.startTime, event.time.endTime)}</span>
+        <span className="calendar-event-detail-time">{formatInterval(event.time.interval)}</span>
         {detail}
       </React.Fragment>
     );
@@ -176,7 +178,7 @@ export function MentorSectionPreferences({
                 {event.times.map((time, time_idx) => (
                   <li key={time_idx} className="matcher-selected-time-container">
                     <span className="matcher-selected-time">
-                      {time.day} {formatTime(time.startTime)}&#8211;{formatTime(time.endTime)}
+                      {time.day} {formatInterval(time.interval)}
                     </span>
                   </li>
                 ))}

--- a/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
@@ -1,22 +1,21 @@
+import { DateTime, Duration, Interval } from "luxon";
 import React, { useEffect, useMemo, useRef, useState } from "react";
-import { formatTime } from "../utils";
+import { DATETIME_INITIAL_INVALID, formatTime, INTERVAL_INITIAL_INVALID } from "../../../utils/datetime";
+
+import { Time } from "../EnrollmentAutomationTypes";
 import { CalendarDay, CalendarDayHeader } from "./CalendarDay";
 import { CalendarEvent, CalendarEventSingleTime, DAYS } from "./CalendarTypes";
 
 // default start and end times for calendar
-const START = 8 * 60 + 0; // 8:00 AM
-const END = 18 * 60 + 0; // 6:00 PM
-const INTERVAL_LENGTH = 30;
-const SCROLL_AMT = 30;
+const START = DateTime.fromObject({ hour: 8, minute: 0 }); // 8:00 AM
+const END = DateTime.fromObject({ hour: 18, minute: 0 }); // 6:00 PM
+const INTERVAL_LENGTH = Duration.fromObject({ minutes: 30 });
+const SCROLL_AMT = Duration.fromObject({ minutes: 30 });
+
+const MIN = DateTime.fromObject({ hour: 0, minute: 0 });
+const MAX = DateTime.fromObject({ hour: 24, minute: 0 });
 
 const WIDTH_SCALE = 0.9;
-
-interface Time {
-  day: string;
-  startTime: number;
-  endTime: number;
-  isLinked: boolean; // whether this time is linked to another within a section
-}
 
 interface CalendarProps {
   events: CalendarEvent[];
@@ -52,38 +51,64 @@ export function Calendar({
   brighterLinkedTimes,
   flushDetails
 }: CalendarProps): React.ReactElement {
-  const [viewBounds, setViewBounds] = useState<{ start: number; end: number }>({ start: START, end: END });
+  /**
+   * User viewing bounds of the calendar events.
+   */
+  const [viewBounds, setViewBounds] = useState<Interval>(Interval.fromDateTimes(START, END));
 
+  /** Height of an interval in pixels. */
   const [intervalHeight, setIntervalHeight] = useState<number>(0);
+  /** Width of an interval in pixels; takes `WIDTH_SCALE` into account. */
   const [intervalWidth, setIntervalWidth] = useState<number>(0);
+  /** Index of the current event the user is hovering over. */
   const [eventHoverIndex, setEventHoverIndex] = useState<number>(-1);
 
+  /**
+   * Whether the user is currently creating an event.
+   */
   const [creatingEvent, setCreatingEvent] = useState<boolean>(false);
-  const [curCreatedEvent, setCurCreatedEvent] = useState<Time>({
+  /**
+   * The event that should be shown as the user is in the process of dragging to create a new event.
+   *
+   * While dragging, the end time may be before the start time;
+   * the start time is set on mouse down, and the end time is set during dragging
+   * and on mouse up.
+   *
+   * @see normalizeCreatedEvent - creates a valid event from the information here;
+   *    in particular, swaps the start and end time if the end time is prior to the start time.
+   */
+  const [curCreatedEvent, setCurCreatedEvent] = useState<{
+    day: string;
+    start: DateTime;
+    end: DateTime;
+    isLinked: boolean;
+  }>({
     day: "",
-    startTime: -1,
-    endTime: -1,
+    start: DATETIME_INITIAL_INVALID,
+    end: DATETIME_INITIAL_INVALID,
     isLinked: false
   });
 
-  const [eventExtrema, setEventExtrema] = useState<{ min: number; max: number }>({
-    min: Number.MIN_VALUE,
-    max: Number.MAX_VALUE
-  });
-
-  useEffect(() => {
-    const newExtrema = events.reduce(
-      ({ min, max }, event) => {
-        const start = Math.min(...event.times.map(t => t.startTime));
-        const end = Math.max(...event.times.map(t => t.endTime));
-        return { min: Math.min(min, start), max: Math.max(max, end) };
-      },
-      { min: Number.MAX_VALUE, max: Number.MIN_VALUE }
+  /**
+   * Union of all event intervals.
+   *
+   * This is used for limiting how much the user can scroll the calendar viewport.
+   */
+  const eventExtrema = useMemo(() => {
+    return (
+      events.reduce((curExtrema: Interval | null, event) => {
+        return event.times.reduce((merged, current) => {
+          if (merged == null) {
+            return current.interval;
+          } else {
+            return merged.union(current.interval);
+          }
+        }, curExtrema);
+      }, null) ?? Interval.invalid("no events")
     );
-    setEventExtrema(newExtrema);
   }, [events]);
 
-  // re-register scroll listener whenever the extrema states change; otherwise, scrollView uses stale values
+  /** Re-register scroll listener whenever the extrema states change; otherwise, `scrollView` uses stale values. */
   useEffect(() => {
     calendarBodyRef.current?.addEventListener<"wheel">("wheel", scrollView, { passive: false });
     return () => {
@@ -91,7 +116,7 @@ export function Calendar({
     };
   }, [eventExtrema]);
 
-  // reference for calendar body mousewheel event listener
+  /** Reference for the calendar body mousewheel event listener. */
   const calendarBodyRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -120,6 +145,17 @@ export function Calendar({
     onCreateDragEndCancel(e);
   };
 
+  /**
+   * Add event listeners for canceling drag events.
+   *
+   * In particular, if the user releases the mouse outside of the calendar,
+   * or unfocuses from the window, the drag should be canceled.
+   *
+   * Cleans up event listeners when the component is destroyed.
+   *
+   * If event creation is not enabled, the event listeners are not added;
+   * this reduces the amount of attached event listeners in the window.
+   */
   useEffect(() => {
     window.removeEventListener("mouseup", mouseupListener);
     window.removeEventListener("blur", blurListener);
@@ -135,8 +171,18 @@ export function Calendar({
     }
   }, [eventCreationEnabled]);
 
+  /**
+   * Scroll the calendar view.
+   *
+   * @param e - scroll event
+   */
   const scrollView = (e: WheelEvent) => {
-    if (limitScrolling && eventExtrema.min >= viewBounds.start + 60 && eventExtrema.max <= viewBounds.end - 60) {
+    if (
+      !eventExtrema.isValid ||
+      (limitScrolling &&
+        eventExtrema.start! >= viewBounds.start!.plus(Duration.fromObject({ hours: 1 })) &&
+        eventExtrema.end! <= viewBounds.end!.minus(Duration.fromObject({ hours: 1 })))
+    ) {
       // everything is in the viewport; don't scroll
       return;
     }
@@ -148,24 +194,17 @@ export function Calendar({
     if (e.deltaY < 0) {
       // don't update past midnight
       setViewBounds(prevBounds => {
-        if (prevBounds.start >= SCROLL_AMT) {
-          return {
-            start: prevBounds.start - SCROLL_AMT,
-            end: prevBounds.end - SCROLL_AMT
-          };
+        if (prevBounds.start! >= MIN.plus(SCROLL_AMT)) {
+          return prevBounds.mapEndpoints(datetime => datetime.minus(SCROLL_AMT));
         } else {
           return prevBounds;
         }
       });
     } else if (e.deltaY > 0) {
       // don't update past midnight
-      const limit = 24 * 60 - SCROLL_AMT;
       setViewBounds(prevBounds => {
-        if (prevBounds.end <= limit) {
-          return {
-            start: prevBounds.start + SCROLL_AMT,
-            end: prevBounds.end + SCROLL_AMT
-          };
+        if (prevBounds.end! <= MAX.minus(SCROLL_AMT)) {
+          return prevBounds.mapEndpoints(datetime => datetime.minus(SCROLL_AMT));
         } else {
           return prevBounds;
         }
@@ -173,35 +212,45 @@ export function Calendar({
     }
   };
 
-  const categorizedEvents: { [day: string]: any } = {};
+  /**
+   * Categorized events by day; memoized, since this only changes if the events change.
+   *
+   * The resulting categorized event includes the original index in the events list.
+   */
+  const categorizedEvents = useMemo(() => {
+    const newCategorizedEvents: {
+      [day: string]: { event_idx: number; event: CalendarEventSingleTime; isLinked: boolean }[];
+    } = {};
 
-  for (let i = 0; i < events.length; i++) {
-    const event = events[i];
-    const { times, ...rest } = event;
-    const isLinked = times.length > 1;
-    for (const time of times) {
-      if (!categorizedEvents[time.day]) {
-        categorizedEvents[time.day] = [];
+    for (let i = 0; i < events.length; i++) {
+      const event = events[i];
+      const { times, ...rest } = event;
+      const isLinked = times.length > 1;
+      for (const time of times) {
+        if (!newCategorizedEvents[time.day]) {
+          newCategorizedEvents[time.day] = [];
+        }
+
+        const newEvent: CalendarEventSingleTime = {
+          time,
+          ...rest
+        };
+
+        newCategorizedEvents[time.day].push({
+          event_idx: i,
+          event: newEvent,
+          isLinked
+        });
       }
-
-      const newEvent: CalendarEventSingleTime = {
-        time,
-        ...rest
-      };
-
-      categorizedEvents[time.day].push({
-        event_idx: i,
-        event: newEvent,
-        isLinked
-      });
     }
-  }
+    return newCategorizedEvents;
+  }, [events]);
 
   /**
    * Wrapper for when an event is clicked.
    *
-   * @param index event index in array
-   * @param add whether to add event or replace existing events
+   * @param index - event index in array
+   * @param add - whether to add event or replace existing events
    */
   const eventClickWrapper = (index: number, add: boolean) => {
     let newSelectedEventIndices;
@@ -218,54 +267,104 @@ export function Calendar({
     onEventClick(index);
   };
 
-  const onCreateDragStart = (day: string, startTime: number, endTime: number) => {
+  /**
+   * Event handler for when the user begins to drag in the calendar to create a new event.
+   *
+   * @param day - the day (column) the user started dragging in
+   * @param interval - the time interval (row) the user started dragging in
+   */
+  const onCreateDragStart = (day: string, interval: Interval) => {
     if (!eventCreationEnabled) {
       return;
     }
-    setCurCreatedEvent({ day, startTime, endTime, isLinked: createdTimes.length > 0 });
+    setCurCreatedEvent({
+      day,
+      start: interval.start!,
+      end: interval.end!,
+      isLinked: createdTimes.length > 0
+    });
     setCreatingEvent(true);
     setEventHoverIndex(-1);
     setSelectedEventIndices([]);
     onEventBeginCreation(normalizeCreatedEvent());
   };
 
-  const onCreateDragOver = (day: string, start_time: number, end_time: number) => {
+  /**
+   * Event handler for when the user drags over a new interval when creating a new event.
+   *
+   * Changes only the end time of the currently created event.
+   *
+   * @param day - the day (column) the user is currently dragging over
+   * @param interval - the time interval (row) the user is currently dragging over
+   */
+  const onCreateDragOver = (day: string, interval: Interval) => {
     if (!eventCreationEnabled || !creatingEvent) {
       return;
     }
     setCurCreatedEvent({
-      day: curCreatedEvent.day,
-      startTime: curCreatedEvent.startTime,
-      endTime: end_time,
-      isLinked: curCreatedEvent.isLinked
+      ...curCreatedEvent,
+      end: interval.end!
     });
   };
 
-  const onCreateDragEnd = (day: string, start_time: number, end_time: number) => {
+  /**
+   * Event handler for when the user stops dragging when creating a new event.
+   *
+   * @param day - the day (column) the user ended the drag in
+   * @param interval - the time interval (row) the user ended the drag in
+   */
+  const onCreateDragEnd = (day: string, interval: Interval) => {
     if (!eventCreationEnabled || !creatingEvent) {
       return;
     }
     onEventCreated(normalizeCreatedEvent());
-    setCurCreatedEvent({ day: "", startTime: -1, endTime: -1, isLinked: false });
+    setCurCreatedEvent({
+      day: "",
+      start: DATETIME_INITIAL_INVALID,
+      end: DATETIME_INITIAL_INVALID,
+      isLinked: false
+    });
     setCreatingEvent(false);
   };
 
+  /**
+   * Event handler for when the user cancels dragging during event creation.
+   *
+   * @param e - event that caused the cancellation of the drag
+   */
   const onCreateDragEndCancel = (e: MouseEvent | FocusEvent) => {
-    setCurCreatedEvent({ day: "", startTime: -1, endTime: -1, isLinked: false });
+    setCurCreatedEvent({
+      day: "",
+      start: DATETIME_INITIAL_INVALID,
+      end: DATETIME_INITIAL_INVALID,
+      isLinked: false
+    });
     setCreatingEvent(false);
   };
 
+  /** Normalze the current event being created, to prepare for the finalization of the new event. */
   const normalizeCreatedEvent = () => {
-    if (curCreatedEvent.startTime < curCreatedEvent.endTime) {
-      return curCreatedEvent;
-    } else {
-      return {
-        day: curCreatedEvent.day,
-        startTime: curCreatedEvent.endTime - INTERVAL_LENGTH,
-        endTime: curCreatedEvent.startTime + INTERVAL_LENGTH,
-        isLinked: curCreatedEvent.isLinked
-      };
+    let interval = INTERVAL_INITIAL_INVALID;
+    if (!curCreatedEvent.start.isValid || !curCreatedEvent.end.isValid) {
+      // invalid endpoints, so use an invalid interval
+    } else if (curCreatedEvent.start < curCreatedEvent.end) {
+      // no need to swap; create interval normally
+      interval = Interval.fromDateTimes(curCreatedEvent.start, curCreatedEvent.end);
+    } else if (curCreatedEvent.start >= curCreatedEvent.end) {
+      interval = Interval.fromDateTimes(
+        // shift event end, since it's set from the interval end and needs to be the interval start.
+        curCreatedEvent.end.minus(INTERVAL_LENGTH),
+        // shift event start, since it's set from the initial interval start,
+        // and needs to be the interval end in order to include the cell the user started at.
+        curCreatedEvent.start.plus(INTERVAL_LENGTH)
+      );
     }
+
+    return {
+      day: curCreatedEvent.day,
+      interval,
+      isLinked: curCreatedEvent.isLinked
+    };
   };
 
   return (
@@ -278,13 +377,12 @@ export function Calendar({
           ))}
         </div>
         <div className="calendar-body" ref={calendarBodyRef}>
-          <CalendarLabels startTime={viewBounds.start} endTime={viewBounds.end} intervalLength={INTERVAL_LENGTH} />
+          <CalendarLabels interval={viewBounds} intervalLength={INTERVAL_LENGTH} />
           {DAYS.map((day, idx) => (
             <CalendarDay
               key={idx}
               day={day}
-              startTime={viewBounds.start}
-              endTime={viewBounds.end}
+              interval={viewBounds}
               intervalLength={INTERVAL_LENGTH}
               eventHoverIndex={disableHover ? -1 : eventHoverIndex}
               eventSelectIndices={selectedEventIndices}
@@ -333,17 +431,16 @@ Calendar.defaultProps = {
 };
 
 interface CalendarLabelsProps {
-  startTime: number;
-  endTime: number;
-  intervalLength: number;
+  interval: Interval;
+  intervalLength: Duration;
 }
 
-function CalendarLabels({ startTime, endTime, intervalLength }: CalendarLabelsProps): React.ReactElement {
+function CalendarLabels({ interval, intervalLength }: CalendarLabelsProps): React.ReactElement {
   const labels: React.ReactElement[] = [];
-  for (let i = startTime; i < endTime; i += intervalLength) {
+  for (let d = interval.start!; d < interval.end!; d = d.plus(intervalLength)) {
     labels.push(
-      <div className="calendar-label" key={i}>
-        {i % 60 == 0 ? formatTime(i) : ""}
+      <div className="calendar-label" key={d.toMillis()}>
+        {d.get("minute") % 60 == 0 ? formatTime(d) : ""}
       </div>
     );
   }

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/ConfigureStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/ConfigureStage.tsx
@@ -6,7 +6,7 @@ import LoadingSpinner from "../../LoadingSpinner";
 import { Calendar } from "../calendar/Calendar";
 import { CalendarEventSingleTime } from "../calendar/CalendarTypes";
 import { Slot } from "../EnrollmentAutomationTypes";
-import { formatInterval } from "../utils";
+import { formatInterval } from "../../../utils/datetime";
 
 import CheckCircle from "../../../../static/frontend/img/check_circle.svg";
 import ErrorCircle from "../../../../static/frontend/img/error_outline.svg";
@@ -82,7 +82,7 @@ export const ConfigureStage = ({ profile, slots, recomputeStage }: ConfigureStag
   const getEventDetails = (event: CalendarEventSingleTime) => {
     return (
       <React.Fragment>
-        <span className="calendar-event-detail-time">{formatInterval(event.time.startTime, event.time.endTime)}</span>
+        <span className="calendar-event-detail-time">{formatInterval(event.time.interval)}</span>
         <br />
         <span className="matcher-mentor-min-max">
           ({minMentorMap.get(event.id)}&#8211;{maxMentorMap.get(event.id)})

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/CoordinatorMatcherForm.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/CoordinatorMatcherForm.tsx
@@ -1,7 +1,8 @@
+import { Interval } from "luxon";
 import React, { useEffect, useState } from "react";
+
 import { Profile } from "../../../utils/types";
 import { parseTime } from "../utils";
-
 import {
   useMatcherAssignment,
   useMatcherConfig,
@@ -63,8 +64,7 @@ export function CoordinatorMatcherForm({
     const new_slots: Slot[] = jsonSlots.slots.map((slot: { id: number; times: StrTime[] }) => {
       const new_times: Time[] = slot.times.map((time: StrTime) => {
         return {
-          startTime: parseTime(time.startTime),
-          endTime: parseTime(time.endTime),
+          interval: Interval.fromDateTimes(parseTime(time.startTime), parseTime(time.endTime)),
           day: time.day,
           isLinked: slot.times.length > 0
         };

--- a/csm_web/frontend/src/components/enrollment_automation/coordinator/ReleaseStage.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/coordinator/ReleaseStage.tsx
@@ -14,7 +14,7 @@ import { Tooltip } from "../../Tooltip";
 import { Calendar } from "../calendar/Calendar";
 import { CalendarEventSingleTime } from "../calendar/CalendarTypes";
 import { Slot, SlotPreference } from "../EnrollmentAutomationTypes";
-import { formatInterval } from "../utils";
+import { formatInterval } from "../../../utils/datetime";
 
 import CheckIcon from "../../../../static/frontend/img/check.svg";
 import CheckCircleIcon from "../../../../static/frontend/img/check_circle.svg";
@@ -604,9 +604,7 @@ function PreferenceStatusModal({
           placement="top"
           source={
             <div className="matcher-pref-distribution-div" style={{ backgroundColor: prefColor }}>
-              <span className="calendar-event-detail-time">
-                {formatInterval(event.time.startTime, event.time.endTime)}
-              </span>
+              <span className="calendar-event-detail-time">{formatInterval(event.time.interval)}</span>
             </div>
           }
         >

--- a/csm_web/frontend/src/components/enrollment_automation/utils.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/utils.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { DateTime } from "luxon";
 
 /**
  * Maximum preference for mentors
@@ -6,60 +6,20 @@ import React from "react";
 export const MAX_PREFERENCE = 5;
 
 /**
- * Convert 24hr time to 12hr time
- *
- * @param time string in format "HH:MM"
- */
-export function formatTime(time: number, show_ampm = true): string {
-  const hours = Math.floor(time / 60);
-  const minutes = time % 60;
-  let ampm;
-  if (show_ampm) {
-    ampm = hours >= 12 ? "pm" : "am";
-  } else {
-    ampm = "";
-  }
-  if (minutes == 0) {
-    return `${hours > 12 ? hours % 12 : hours === 0 ? 12 : hours}${ampm}`;
-  }
-  return `${hours > 12 ? hours % 12 : hours === 0 ? 12 : hours}:${minutes}${ampm}`;
-}
-
-export function formatInterval(start: number, end: number) {
-  const startHours = Math.floor(start / 60);
-  const endHours = Math.floor(end / 60);
-  if ((startHours >= 12 && endHours < 12) || (startHours < 12 && endHours >= 12)) {
-    return (
-      <React.Fragment>
-        {formatTime(start)} &ndash; {formatTime(end)}
-      </React.Fragment>
-    );
-  } else {
-    return (
-      <React.Fragment>
-        {formatTime(start, false)} &ndash; {formatTime(end)}
-      </React.Fragment>
-    );
-  }
-}
-
-/**
  * Serialize time into HH:MM format
  *
  * @param time number of minutes past midnight
  */
-export function serializeTime(time: number): string {
-  const hours = Math.floor(time / 60);
-  const minutes = time % 60;
-  return `${hours < 10 ? "0" : ""}${hours}:${minutes < 10 ? "0" : ""}${minutes}`;
+export function serializeTime(time: DateTime): string {
+  return time.toFormat("HH:mm")!;
 }
 
 /**
- * Parses a 24h time string and returns the number of minutes past midnight.
+ * Parses a 24h time string into a DateTime object
+ *
  * @param time 24h time string
- * @returns minutes past midnight
+ * @returns datetime object
  */
-export function parseTime(time: string): number {
-  const [hours, minutes] = time.split(":");
-  return parseInt(hours) * 60 + parseInt(minutes);
+export function parseTime(time: string): DateTime {
+  return DateTime.fromFormat(time, "HH:mm");
 }

--- a/csm_web/frontend/src/components/resource_aggregation/ResourceRowRender.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/ResourceRowRender.tsx
@@ -4,6 +4,8 @@ import { Resource } from "./ResourceTypes";
 
 import Pencil from "../../../static/frontend/img/pencil.svg";
 import Trash from "../../../static/frontend/img/trash-alt.svg";
+import { formatDate } from "../../utils/datetime";
+import { DateTime } from "luxon";
 
 interface ResourceRowRenderProps {
   resource: Resource;
@@ -58,7 +60,7 @@ const ResourceRowRender = ({ resource, canEdit, onSetEdit, onDelete }: ResourceR
           <div>Week {resource.weekNum}</div>
         </div>
         <div className="resourceInfo dateCell">
-          <div>{resource.date}</div>
+          <div>{formatDate(DateTime.fromISO(resource.date))}</div>
         </div>
         <div className="resourceInfo resourceTopics">
           <ResourceTopics topics={resource.topics} />

--- a/csm_web/frontend/src/components/resource_aggregation/ResourceRowRender.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/ResourceRowRender.tsx
@@ -4,7 +4,7 @@ import { Resource } from "./ResourceTypes";
 
 import Pencil from "../../../static/frontend/img/pencil.svg";
 import Trash from "../../../static/frontend/img/trash-alt.svg";
-import { formatDate } from "../../utils/datetime";
+import { DEFAULT_TIMEZONE, formatDate } from "../../utils/datetime";
 import { DateTime } from "luxon";
 
 interface ResourceRowRenderProps {
@@ -60,7 +60,7 @@ const ResourceRowRender = ({ resource, canEdit, onSetEdit, onDelete }: ResourceR
           <div>Week {resource.weekNum}</div>
         </div>
         <div className="resourceInfo dateCell">
-          <div>{formatDate(DateTime.fromISO(resource.date))}</div>
+          <div>{formatDate(DateTime.fromISO(resource.date, { zone: DEFAULT_TIMEZONE }))}</div>
         </div>
         <div className="resourceInfo resourceTopics">
           <ResourceTopics topics={resource.topics} />

--- a/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
+++ b/csm_web/frontend/src/components/resource_aggregation/ResourceTable.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { DateTime, Duration } from "luxon";
 
 import {
   useCreateResourceMutation,
@@ -12,6 +13,7 @@ import ResourceRow from "./ResourceRow";
 import { emptyResource, Link, Resource, Worksheet } from "./ResourceTypes";
 
 import PlusCircle from "../../../static/frontend/img/plus-circle.svg";
+import { DEFAULT_TIMEZONE } from "../../utils/datetime";
 
 interface ResourceTableProps {
   courseID: number;
@@ -226,14 +228,11 @@ export const ResourceTable = ({ courseID, roles }: ResourceTableProps): React.Re
     const lastResource = resources[resources.length - 1]; // get last resource
     newResource.weekNum = lastResource.weekNum + 1;
 
-    // add a week
-    const date = new Date(Date.parse(lastResource.date));
-    date.setUTCDate(date.getUTCDate() + 7);
+    // parse date from the resource, and add a week
+    const date = DateTime.fromISO(lastResource.date, { zone: DEFAULT_TIMEZONE }).plus(Duration.fromObject({ week: 1 }));
 
-    // pad month and day
-    const newMonth = `${date.getUTCMonth() + 1}`.padStart(2, "0");
-    const newDay = `${date.getUTCDate()}`.padStart(2, "0");
-    newResource.date = `${date.getUTCFullYear()}-${newMonth}-${newDay}`;
+    // format the new date
+    newResource.date = date.toISODate()!;
     return newResource;
   }
 

--- a/csm_web/frontend/src/components/section/CoordinatorAddStudentModal.tsx
+++ b/csm_web/frontend/src/components/section/CoordinatorAddStudentModal.tsx
@@ -7,6 +7,7 @@ import Modal from "../Modal";
 import CheckCircle from "../../../static/frontend/img/check_circle.svg";
 import ErrorCircle from "../../../static/frontend/img/error_outline.svg";
 import { useEnrollStudentMutation } from "../../utils/queries/sections";
+import { DateTime } from "luxon";
 
 enum CoordModalStates {
   INITIAL = "INITIAL",
@@ -502,7 +503,7 @@ export function CoordinatorAddStudentModal({
     <React.Fragment>
       <h4 className="internal-error-title">Internal Error</h4>
       <div className="internal-error-body">{response && response.errors && response.errors.critical}</div>
-      <div>Timestamp: {`${new Date()}`}</div>
+      <div>Timestamp: {`${DateTime.now().toISO()}`}</div>
     </React.Fragment>
   );
 

--- a/csm_web/frontend/src/components/section/MentorSectionAttendance.tsx
+++ b/csm_web/frontend/src/components/section/MentorSectionAttendance.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../utils/queries/sections";
 import LoadingSpinner from "../LoadingSpinner";
 import { ATTENDANCE_LABELS } from "./Section";
-import { dateSortISO, formatDateISO } from "./utils";
+import { dateSortISO, formatDateLocaleShort } from "./utils";
 import { Attendance } from "../../utils/types";
 import randomWords from "random-words";
 
@@ -256,7 +256,7 @@ const MentorSectionAttendance = ({ sectionId }: MentorSectionAttendanceProps): R
                     className={id === selectedOccurrence!.id ? "active" : ""}
                     onClick={() => handleSelectOccurrence({ id, date })}
                   >
-                    {formatDateISO(date)}
+                    {formatDateLocaleShort(date)}
                   </div>
                 ))}
               </div>
@@ -299,7 +299,7 @@ const MentorSectionAttendance = ({ sectionId }: MentorSectionAttendanceProps): R
               </div>
               <div id="word-of-the-day-container">
                 <h4 className="word-of-the-day-title">
-                  Word of the Day ({selectedOccurrence ? formatDateISO(selectedOccurrence.date) : "unselected"})
+                  Word of the Day ({selectedOccurrence ? formatDateLocaleShort(selectedOccurrence.date) : "unselected"})
                 </h4>
                 {wotdLoaded ? (
                   <React.Fragment>

--- a/csm_web/frontend/src/components/section/Section.tsx
+++ b/csm_web/frontend/src/components/section/Section.tsx
@@ -5,6 +5,7 @@ import MentorSection from "./MentorSection";
 import { Override, Spacetime } from "../../utils/types";
 import { useSection } from "../../utils/queries/sections";
 import LoadingSpinner from "../LoadingSpinner";
+import { formatSpacetimeInterval } from "../../utils/datetime";
 
 export const ROLES = Object.freeze({ COORDINATOR: "COORDINATOR", STUDENT: "STUDENT", MENTOR: "MENTOR" });
 
@@ -89,24 +90,19 @@ interface SectionSpacetimeProps {
   override?: Override;
 }
 
-export function SectionSpacetime({
-  manySpacetimes,
-  index,
-  spacetime: { location, time },
-  override,
-  children
-}: SectionSpacetimeProps) {
+export function SectionSpacetime({ manySpacetimes, index, spacetime, override, children }: SectionSpacetimeProps) {
+  const location = spacetime.location;
   return (
     <InfoCard title={`Time and Location${manySpacetimes ? ` ${index + 1}` : ""}`}>
       {children}
       <Location location={location} />
-      <h5>{time}</h5>
+      <h5>{formatSpacetimeInterval(spacetime)}</h5>
       {override && (
         <React.Fragment>
           <div className="divider" />
           <div className="override-label">Adjusted for {override.date}</div>
           <Location location={override.spacetime.location} />
-          <h5>{override.spacetime.time}</h5>
+          <h5>{formatSpacetimeInterval(override.spacetime)}</h5>
         </React.Fragment>
       )}
     </InfoCard>

--- a/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
@@ -1,10 +1,11 @@
+import { DateTime } from "luxon";
 import React, { useState } from "react";
 import { useSpacetimeModifyMutation, useSpacetimeOverrideMutation } from "../../utils/queries/spacetime";
 import { Spacetime } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 import TimeInput from "../TimeInput";
-import { DAYS_OF_WEEK, zeroPadTwoDigit } from "./utils";
+import { DAYS_OF_WEEK } from "./utils";
 
 interface SpacetimeEditModalProps {
   sectionId: number;
@@ -49,8 +50,7 @@ const SpaceTimeEditModal = ({
     closeModal();
   };
 
-  const now = new Date();
-  const today = `${now.getFullYear()}-${zeroPadTwoDigit(now.getMonth() + 1)}-${zeroPadTwoDigit(now.getDate())}`;
+  const today = DateTime.now().toISODate()!;
 
   return (
     <Modal className="spacetime-edit-modal" closeModal={closeModal}>

--- a/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
@@ -1,11 +1,11 @@
 import { DateTime } from "luxon";
 import React, { useState } from "react";
+import { DAYS_OF_WEEK } from "../../utils/datetime";
 import { useSpacetimeModifyMutation, useSpacetimeOverrideMutation } from "../../utils/queries/spacetime";
 import { Spacetime } from "../../utils/types";
 import LoadingSpinner from "../LoadingSpinner";
 import Modal from "../Modal";
 import TimeInput from "../TimeInput";
-import { DAYS_OF_WEEK } from "./utils";
 
 interface SpacetimeEditModalProps {
   sectionId: number;
@@ -20,10 +20,9 @@ const SpaceTimeEditModal = ({
   defaultSpacetime: { id: spacetimeId, startTime: timeString, location: prevLocation, dayOfWeek },
   editingOverride
 }: SpacetimeEditModalProps): React.ReactElement => {
-  const sliceIndex = timeString.split(":").length < 3 ? timeString.indexOf(":") : timeString.lastIndexOf(":");
   const [location, setLocation] = useState<Spacetime["location"]>(prevLocation);
   const [day, setDay] = useState<Spacetime["dayOfWeek"]>(dayOfWeek);
-  const [time, setTime] = useState<Spacetime["time"]>(timeString.slice(0, sliceIndex));
+  const [time, setTime] = useState<Spacetime["startTime"]>(timeString);
   const [isPermanent, setIsPermanent] = useState<boolean>(false);
   const [date, setDate] = useState<string>("");
   const [mode, setMode] = useState<string>(prevLocation && prevLocation.startsWith("http") ? "virtual" : "inperson");
@@ -38,13 +37,13 @@ const SpaceTimeEditModal = ({
     setShowSaveSpinner(true);
     isPermanent
       ? spacetimeModifyMutation.mutate({
-          day_of_week: day,
+          dayOfWeek,
           location: location,
-          start_time: `${time}:00`
+          startTime: time
         })
       : spacetimeOverrideMutation.mutate({
           location: location,
-          start_time: `${time}:00`,
+          startTime: time,
           date: date
         });
     closeModal();
@@ -100,15 +99,15 @@ const SpaceTimeEditModal = ({
           <label>
             Day
             <select
-              onChange={e => setDay(e.target.value)}
+              onChange={e => setDay(parseInt(e.target.value))}
               required={!!isPermanent}
               name="day"
               disabled={!isPermanent}
               value={isPermanent ? day : "---"}
             >
-              {["---"].concat(Array.from(DAYS_OF_WEEK)).map(value => (
+              {[["---", ""], ...Array.from(DAYS_OF_WEEK)].map(([label, value]) => (
                 <option key={value} value={value} disabled={value === "---"}>
-                  {value}
+                  {label}
                 </option>
               ))}
             </select>

--- a/csm_web/frontend/src/components/section/utils.tsx
+++ b/csm_web/frontend/src/components/section/utils.tsx
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 export const MONTH_NUMBERS: Readonly<{ [month: string]: number }> = Object.freeze({
   Jan: 1,
   Feb: 2,
@@ -24,81 +26,34 @@ export const DAYS_OF_WEEK: Readonly<string[]> = Object.freeze([
 ]);
 
 /**
- * Convert date of form yyyy-mm-dd to mm/dd.
+ * Convert date from ISO to mm/dd/yy.
  *
  * Example:
- * formatDate("2022-01-06") --> "1/6"
+ * formatDate("2022-01-06") --> "1/6/22"
  */
-export function formatDateISO(dateString: string): string {
-  const [, /* ignore year */ month, day] = dateString.split("-").map(part => parseInt(part));
-  return `${month}/${day}`;
+export function formatDateLocaleShort(dateString: string): string {
+  return DateTime.fromISO(dateString).toLocaleString({
+    ...DateTime.DATE_SHORT,
+    // use 2-digit year
+    year: "2-digit"
+  });
 }
 
 /**
- * Convert date of form Month. day, year to mm/dd.
+ * Convert date from ISO to "Month day, year"
  *
  * Example:
- * formatDate("Jan. 6, 2022") --> "1/6"
+ * formatDate("2022-01-06") --> "Jan 6, 2022"
  */
-export function formatDateWord(dateString: string): string {
-  const [month, dayAndYear] = dateString.split(".");
-  const day = dayAndYear.split(",")[0].trim();
-  return `${MONTH_NUMBERS[month]}/${day}`;
+export function formatDateAbbrevWord(dateString: string): string {
+  return DateTime.fromISO(dateString).toLocaleString(DateTime.DATE_MED);
 }
 
 /**
- * Convert date of form yyyy-mm-dd to MOnth. day, year
- *
- * Example:
- * formatDate("2022-01-06") --> "Jan. 6, 2022"
- */
-export function formatDateISOToWord(dateString: string): string {
-  const [year, month, day] = dateString.split("-").map(part => parseInt(part));
-
-  // get word version of month
-  for (const [monthWord, monthNumber] of Object.entries(MONTH_NUMBERS)) {
-    if (monthNumber === month) {
-      // format with word
-      return `${monthWord}. ${day}, ${year}`;
-    }
-  }
-  return "";
-}
-
-/**
- * Conert date of form Month. day, year into mm/dd/yyyy.
- *
- * Example:
- * formatDateYear("Jan. 6, 2022") --> 1/6/2022
- */
-function formatDateYear(dateString: string): string {
-  const year = dateString.split(",")[1];
-  const formattedDate = formatDateWord(dateString);
-  return `${formattedDate}/${year.trim()}`;
-}
-
-/**
- * Sort two dates of the form yyyy-mm-dd.
+ * Sort two dates in ISO.
  */
 export function dateSortISO(date1: string, date2: string) {
-  const [year1, month1, day1] = date1.split("-").map(part => parseInt(part));
-  const [year2, month2, day2] = date2.split("-").map(part => parseInt(part));
-  return year2 - year1 || month2 - month1 || day2 - day1;
-}
-
-/**
- * Sort two dates of the form Month. day, year.
- *
- * Example: sorting dates like Jan. 6, 2022
- */
-export function dateSortWord(date1: string, date2: string) {
-  const [month1, day1, year1] = formatDateYear(date1)
-    .split("/")
-    .map(part => Number(part));
-  const [month2, day2, year2] = formatDateYear(date2)
-    .split("/")
-    .map(part => Number(part));
-  return year2 - year1 || month2 - month1 || day2 - day1;
+  return DateTime.fromISO(date2).diff(DateTime.fromISO(date1)).as("milliseconds");
 }
 
 export function zeroPadTwoDigit(num: number) {

--- a/csm_web/frontend/src/components/section/utils.tsx
+++ b/csm_web/frontend/src/components/section/utils.tsx
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import { DEFAULT_TIMEZONE } from "../../utils/datetime";
 
 export const MONTH_NUMBERS: Readonly<{ [month: string]: number }> = Object.freeze({
   Jan: 1,
@@ -15,16 +16,6 @@ export const MONTH_NUMBERS: Readonly<{ [month: string]: number }> = Object.freez
   Dec: 12
 });
 
-export const DAYS_OF_WEEK: Readonly<string[]> = Object.freeze([
-  "Monday",
-  "Tuesday",
-  "Wednesday",
-  "Thursday",
-  "Friday",
-  "Saturday",
-  "Sunday"
-]);
-
 /**
  * Convert date from ISO to mm/dd/yy.
  *
@@ -32,7 +23,7 @@ export const DAYS_OF_WEEK: Readonly<string[]> = Object.freeze([
  * formatDate("2022-01-06") --> "1/6/22"
  */
 export function formatDateLocaleShort(dateString: string): string {
-  return DateTime.fromISO(dateString).toLocaleString({
+  return DateTime.fromISO(dateString, { zone: DEFAULT_TIMEZONE }).toLocaleString({
     ...DateTime.DATE_SHORT,
     // use 2-digit year
     year: "2-digit"
@@ -46,14 +37,16 @@ export function formatDateLocaleShort(dateString: string): string {
  * formatDate("2022-01-06") --> "Jan 6, 2022"
  */
 export function formatDateAbbrevWord(dateString: string): string {
-  return DateTime.fromISO(dateString).toLocaleString(DateTime.DATE_MED);
+  return DateTime.fromISO(dateString, { zone: DEFAULT_TIMEZONE }).toLocaleString(DateTime.DATE_MED);
 }
 
 /**
  * Sort two dates in ISO.
  */
 export function dateSortISO(date1: string, date2: string) {
-  return DateTime.fromISO(date2).diff(DateTime.fromISO(date1)).as("milliseconds");
+  const datetime1 = DateTime.fromISO(date1, { zone: DEFAULT_TIMEZONE });
+  const datetime2 = DateTime.fromISO(date2, { zone: DEFAULT_TIMEZONE });
+  return datetime2.diff(datetime1).as("milliseconds");
 }
 
 export function zeroPadTwoDigit(num: number) {

--- a/csm_web/frontend/src/utils/datetime.tsx
+++ b/csm_web/frontend/src/utils/datetime.tsx
@@ -1,0 +1,57 @@
+import { DateTime, DateTimeFormatOptions, IANAZone, Interval } from "luxon";
+
+export const DEFAULT_TIMEZONE = IANAZone.create("America/Los_Angeles");
+
+export const DEFAULT_LONG_LOCALE_OPTIONS: DateTimeFormatOptions = {
+  weekday: "long",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+  hour12: true,
+  timeZoneName: "short"
+};
+
+export const DATETIME_INITIAL_INVALID = DateTime.invalid("initial value");
+export const INTERVAL_INITIAL_INVALID = Interval.invalid("initial value");
+
+/**
+ * Format a date for display.
+ *
+ * @param datetime - datetime object to format
+ * @returns formatted date
+ */
+export const formatDate = (datetime: DateTime): string => {
+  return datetime.toLocaleString(DateTime.DATE_SHORT);
+};
+
+/**
+ * Format datetime as "HH:MM AM/PM".
+ *
+ * If the minutes are 0, displays "HH AM/PM" if 12-hour.
+ * 24-hour time display has no special handling.
+ *
+ * @param number representing the number of minutes past 12:00 AM
+ */
+export function formatTime(datetime: DateTime) {
+  if (datetime.get("minute") == 0) {
+    return datetime.toLocaleString({ hour: "numeric", hour12: true });
+  } else {
+    return datetime.toLocaleString({ ...DateTime.TIME_SIMPLE, hour12: true, hour: "numeric" });
+  }
+}
+
+/**
+ * Format an interval object.
+ *
+ * If the minutes for both endpoints are 0, then minutes are not displayed
+ * (ex. 10 - 11 AM, instead of 10:00 - 11:00 AM).
+ *
+ */
+export function formatInterval(interval: Interval): string {
+  if (interval.start!.get("minute") != 0 || interval.end!.get("minute") != 0) {
+    return interval.toLocaleString({ hour: "numeric", minute: "2-digit", hour12: true });
+  } else {
+    return interval.toLocaleString({ hour: "numeric", hour12: true });
+  }
+}

--- a/csm_web/frontend/src/utils/datetime.tsx
+++ b/csm_web/frontend/src/utils/datetime.tsx
@@ -1,4 +1,5 @@
-import { DateTime, DateTimeFormatOptions, IANAZone, Interval } from "luxon";
+import { DateTime, DateTimeFormatOptions, Duration, IANAZone, Info, Interval } from "luxon";
+import { Spacetime } from "./types";
 
 export const DEFAULT_TIMEZONE = IANAZone.create("America/Los_Angeles");
 
@@ -7,8 +8,7 @@ export const DEFAULT_LONG_LOCALE_OPTIONS: DateTimeFormatOptions = {
   month: "numeric",
   day: "numeric",
   hour: "numeric",
-  minute: "numeric",
-  hour12: true,
+  minute: "2-digit",
   timeZoneName: "short"
 };
 
@@ -35,9 +35,9 @@ export const formatDate = (datetime: DateTime): string => {
  */
 export function formatTime(datetime: DateTime) {
   if (datetime.get("minute") == 0) {
-    return datetime.toLocaleString({ hour: "numeric", hour12: true });
+    return datetime.toLocaleString({ hour: "numeric" });
   } else {
-    return datetime.toLocaleString({ ...DateTime.TIME_SIMPLE, hour12: true, hour: "numeric" });
+    return datetime.toLocaleString({ ...DateTime.TIME_SIMPLE, hour: "numeric" });
   }
 }
 
@@ -50,8 +50,87 @@ export function formatTime(datetime: DateTime) {
  */
 export function formatInterval(interval: Interval): string {
   if (interval.start!.get("minute") != 0 || interval.end!.get("minute") != 0) {
-    return interval.toLocaleString({ hour: "numeric", minute: "2-digit", hour12: true });
+    return interval.toLocaleString({ hour: "numeric", minute: "2-digit" });
   } else {
-    return interval.toLocaleString({ hour: "numeric", hour12: true });
+    return interval.toLocaleString({ hour: "numeric" });
   }
 }
+
+/**
+ * Create an interval from the day, time, and duration.
+ *
+ * The associated date is not relevant, and should be ignored.
+ * (It's required for the interval to be created; by default,
+ * the date used is the most recent past date that matches the parameters.
+ * This should not be relied upon, however, and is merely an implementation detail.)
+ *
+ * @param day - ISO day of the week (Monday = 1, Tuesday = 2, etc.)
+ * @param time - ISO time of day (no date)
+ * @param duration - number in seconds for how long the interval lasts
+ */
+export function intervalFromDayAndTime(day: number, time: string, duration: number): Interval {
+  const startDateTime = DateTime.fromISO(time, { zone: DEFAULT_TIMEZONE }).set({ weekday: day });
+  const endDateTime = startDateTime.plus(Duration.fromObject({ seconds: duration }));
+
+  return Interval.fromDateTimes(startDateTime, endDateTime);
+}
+
+/**
+ * Format an interval for display as a section time.
+ *
+ * The default formatting used by .toLocaleString() is not desired,
+ * since it includes information about the date.
+ * Since section times are not tied to any dates, this needs to be manually modified
+ * to only include the day of the week,
+ */
+export function formatSectionInterval(interval: Interval): string {
+  const startTime = interval.start!;
+  const endTime = interval.end!;
+
+  // an interval crosses midnight if the days are different
+  const crossesMidnight = startTime.get("day") !== endTime.get("day");
+
+  const defaultOptions: Intl.DateTimeFormatOptions = {
+    weekday: "long",
+    hour: "numeric",
+    minute: "2-digit"
+  };
+
+  if (crossesMidnight) {
+    // custom formatting if the interval crosses midnight, as default shows the date
+    const formattedStart = startTime.toLocaleString(defaultOptions);
+    const formattedEnd = endTime.toLocaleString({ ...defaultOptions, timeZoneName: "short" });
+    return `${formattedStart} \u2013 ${formattedEnd}`;
+  } else {
+    // default locale formatting is fine if the interval does not cross midnight
+    return interval.toLocaleString({
+      ...defaultOptions,
+      timeZoneName: "short"
+    });
+  }
+}
+
+/**
+ * Format a spacetime interval for display.
+ */
+export function formatSpacetimeInterval(spacetime: Spacetime): string {
+  const interval = intervalFromDayAndTime(spacetime.dayOfWeek, spacetime.startTime, spacetime.duration);
+  return formatSectionInterval(interval);
+}
+
+/**
+ * Convert the day of the week as a number in ISO format
+ * to a string in the user's current locale.
+ */
+export function dayOfWeekToLocaleString(dayOfWeek: number): string {
+  return Info.weekdaysFormat("long")[dayOfWeek - 1];
+}
+
+export function dayOfWeekToEnglishString(dayOfWeek: number): string {
+  return Info.weekdaysFormat("long", { locale: "en-us" })[dayOfWeek - 1];
+}
+
+/**
+ * Map from weekday string to the ISO value for the weekday.
+ */
+export const DAYS_OF_WEEK = new Map(Info.weekdaysFormat("long").map((weekday, index) => [weekday, index + 1]));

--- a/csm_web/frontend/src/utils/queries/spacetime.tsx
+++ b/csm_web/frontend/src/utils/queries/spacetime.tsx
@@ -4,15 +4,10 @@
 
 import { useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
 import { fetchWithMethod, HTTP_METHODS } from "../api";
+import { Spacetime } from "../types";
 import { handleError, handlePermissionsError, handleRetry, PermissionError, ServerError } from "./helpers";
 
 /* ===== Mutations ===== */
-
-export interface SpacetimeModifyMutationBody {
-  day_of_week: string;
-  location: string | undefined;
-  start_time: string;
-}
 
 /**
  * Hook to modify a section's spacetime.
@@ -20,10 +15,10 @@ export interface SpacetimeModifyMutationBody {
 export const useSpacetimeModifyMutation = (
   sectionId: number,
   spacetimeId: number
-): UseMutationResult<void, ServerError, SpacetimeModifyMutationBody> => {
+): UseMutationResult<void, ServerError, Partial<Spacetime>> => {
   const queryClient = useQueryClient();
-  const mutationResult = useMutation<void, Error, SpacetimeModifyMutationBody>(
-    async (body: SpacetimeModifyMutationBody) => {
+  const mutationResult = useMutation<void, Error, Partial<Spacetime>>(
+    async (body: Partial<Spacetime>) => {
       const response = await fetchWithMethod(`/spacetimes/${spacetimeId}/modify`, HTTP_METHODS.PUT, body);
       if (response.ok) {
         return;
@@ -78,7 +73,7 @@ export const useSpacetimeDeleteMutation = (
 
 export interface SpacetimeOverrideMutationBody {
   location: string | undefined;
-  start_time: string;
+  startTime: string;
   date: string;
 }
 

--- a/csm_web/frontend/src/utils/types.tsx
+++ b/csm_web/frontend/src/utils/types.tsx
@@ -6,12 +6,11 @@ export interface Override {
 }
 
 export interface Spacetime {
-  dayOfWeek: string;
-  duration: string;
+  dayOfWeek: number;
+  duration: number;
   id: number;
   location?: string;
   startTime: string;
-  time: string;
   override?: Override;
 }
 

--- a/csm_web/frontend/src/utils/types.tsx
+++ b/csm_web/frontend/src/utils/types.tsx
@@ -1,3 +1,5 @@
+import { DateTime } from "luxon";
+
 export interface Override {
   date: string;
   spacetime: Spacetime;
@@ -28,7 +30,7 @@ export interface UserInfo {
   firstName: string;
   lastName: string;
   email: string;
-  priorityEnrollment?: Date;
+  priorityEnrollment?: DateTime;
 }
 
 /**

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -208,9 +208,7 @@ class MentorSerializer(serializers.ModelSerializer):
 
 
 class AttendanceSerializer(serializers.ModelSerializer):
-    date = serializers.DateField(
-        source="sectionOccurrence.date", format="%b. %-d, %Y", read_only=True
-    )
+    date = serializers.DateField(source="sectionOccurrence.date", read_only=True)
     student_name = serializers.CharField(source="student.name")
     student_id = serializers.IntegerField(source="student.id")
     student_email = serializers.CharField(source="student.user.email")

--- a/csm_web/scheduler/views/utils.py
+++ b/csm_web/scheduler/views/utils.py
@@ -7,8 +7,14 @@ from django.db import models
 from django.db.models.query import QuerySet
 from django.shortcuts import get_object_or_404
 from rest_framework import mixins, viewsets
-
-from ..models import User, Section, Spacetime, Override, Attendance
+from scheduler.models import (
+    Attendance,
+    DayOfWeekField,
+    Override,
+    Section,
+    Spacetime,
+    User,
+)
 
 logger = logging.getLogger(__name__)
 logger.info = logger.warning
@@ -31,7 +37,9 @@ def log_str(obj) -> str:
         if isinstance(obj, Section):
             return log_format("pk", "mentor.course.name", "spacetimes.all")
         if isinstance(obj, Spacetime):
-            return log_format("pk", "section.mentor.course.name", "location", "start_time")
+            return log_format(
+                "pk", "section.mentor.course.name", "location", "start_time"
+            )
         if isinstance(obj, Override):
             return log_format("pk", "date", "spacetime.pk")
         if isinstance(obj, Attendance):
@@ -76,3 +84,10 @@ def viewset_with(*permitted_methods: str) -> Any:
             if method in permitted_methods
         }
     ) + [viewsets.GenericViewSet]
+
+
+def weekday_iso_to_string(day_of_week: int) -> str:
+    """
+    Convert a weekday int (in ISO format, where Monday = 1) into a string
+    """
+    return DayOfWeekField.DAYS[day_of_week - 1]

--- a/cypress/e2e/course/coordinator-course.cy.ts
+++ b/cypress/e2e/course/coordinator-course.cy.ts
@@ -30,14 +30,18 @@ const checkCapacity = (text: string, isFull = false) => {
 const checkCardOrder = () => {
   let prevTime: DateTime = null;
   cy.get('[title="Time"]').each($el => {
-    const text = $el.text().trim();
+    const text = $el
+      .text()
+      .trim()
+      // replace all weird spaces; see https://jkorpela.fi/chars/spaces.html
+      .replace(/[\u00A0\u1680\u180E\u2000-\u200B\u202F\u205F\u3000\uFEFF]/, " ");
     // time of form [day] [start]-[end] [AM/PM]
     //   or of form [day] [start] [AM/PM]-[end] [AM/PM]
-    const matches = text.match(/\w+ (\d\d?:\d\d(?: AM| PM)?)-(\d\d?:\d\d (?:A|P)M)/g);
+    const matches = text.match(/\w+, (\d\d?:\d\d(?: AM| PM)?)\s*–\s*(\d\d?:\d\d (?:A|P)M)/g);
     let sectionTime: DateTime = null;
     for (const substr of matches) {
       // get groups in this match
-      const match = substr.match(/\w+ (\d\d?:\d\d(?: AM| PM)?)-(\d\d?:\d\d (?:A|P)M)/);
+      const match = substr.match(/\w+, (\d\d?:\d\d(?: AM| PM)?)\s*–\s*(\d\d?:\d\d (?:A|P)M)/);
       let start = match[1];
       const end_ampm = match[2].match(/AM|PM/i)[0];
       if (start.match(/am|pm/i) === null) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.0.5",
         "js-cookie": "^2.2.1",
         "lodash": "^4.17.21",
+        "luxon": "^3.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0"
@@ -34,6 +35,7 @@
         "@testing-library/react": "^13.4.0",
         "@types/js-cookie": "^3.0.2",
         "@types/lodash": "^4.14.175",
+        "@types/luxon": "^3.3.0",
         "@types/random-words": "^1.1.2",
         "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^5.43.0",
@@ -4215,6 +4217,12 @@
       "version": "4.14.176",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
+      "dev": true
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -12661,6 +12669,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
@@ -18450,6 +18466,12 @@
       "version": "4.14.176",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.176.tgz",
       "integrity": "sha512-xZmuPTa3rlZoIbtDUyJKZQimJV3bxCmzMIO2c9Pz9afyDro6kr7R79GwcB6mRhuoPmV2p1Vb66WOJH7F886WKQ==",
+      "dev": true
+    },
+    "@types/luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-uKRI5QORDnrGFYgcdAVnHvEIvEZ8noTpP/Bg+HeUzZghwinDlIS87DEenV5r1YoOF9G4x600YsUXLWZ19rmTmg==",
       "dev": true
     },
     "@types/node": {
@@ -24838,6 +24860,11 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "luxon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.3.0.tgz",
+      "integrity": "sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg=="
     },
     "lz-string": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@testing-library/react": "^13.4.0",
     "@types/js-cookie": "^3.0.2",
     "@types/lodash": "^4.14.175",
+    "@types/luxon": "^3.3.0",
     "@types/random-words": "^1.1.2",
     "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.43.0",
@@ -76,6 +77,7 @@
     "@types/react-dom": "^18.0.5",
     "js-cookie": "^2.2.1",
     "lodash": "^4.17.21",
+    "luxon": "^3.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0"


### PR DESCRIPTION
Closes #367

Default datetime support in JS is horrible, so Luxon was added to make it a lot easier to manage.

Further, there are some serializers which format dates in the response, which is bad convention, as the backend should provide dates in a standardized format (i.e. ISO), letting the frontend do the formatting; parsing should be made as easy as possible. This was changed in this PR so that serializers give all date/datetime values in ISO.