### PR TITLE
Refactor admin pages

### DIFF
--- a/csm_web/frontend/urls.py
+++ b/csm_web/frontend/urls.py
@@ -1,4 +1,10 @@
-from django.urls import re_path
+from django.urls import path, re_path
+
 from . import views
 
-urlpatterns = [re_path(r"^(?!api/)", views.index)]
+urlpatterns = [
+    # catch index path
+    path("", views.index),
+    # catch all other subpaths
+    re_path(r"^.*/$", views.index),
+]


### PR DESCRIPTION
Fixes #364, fixes #384.

The admin pages are all very outdated, and this PR does a lot of refactoring to make the lists more helpful, and fix a lot of legacy code (especially regarding permissions).

This PR also fixes some URL issues when trying to navigate to the admin page. In particular, the existing URL configuration to route to the frontend wasn't optimal; there was a hard-coded check that the URL does not begin with `api/`. This was changed to two routes; one routing from `/` to the frontend, and one routing any path `^.*/$` to the frontend.

The root cause for #364 turns out to be how Django handles URL matching. Since Django automatically adds a trailing slash if a path matches nothing, it is important that _all_ routes end with `/`, so that paths that do not end in a slash get rerouted with the `/` appended. Prior, the frontend catch-all route was for `^(?!api/)`, which _does_ match paths that do not end in a slash. This means that `/admin` will match this URL, and get passed to the frontend, which is undesired behavior.