### PR TITLE
Fix matcher scrolling

### DIFF
--- a/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
+++ b/csm_web/frontend/src/components/enrollment_automation/calendar/Calendar.tsx
@@ -204,7 +204,7 @@ export function Calendar({
       // don't update past midnight
       setViewBounds(prevBounds => {
         if (prevBounds.end! <= MAX.minus(SCROLL_AMT)) {
-          return prevBounds.mapEndpoints(datetime => datetime.minus(SCROLL_AMT));
+          return prevBounds.mapEndpoints(datetime => datetime.plus(SCROLL_AMT));
         } else {
           return prevBounds;
         }


### PR DESCRIPTION
With the luxon migration, the matcher was refactored to use luxon datetime objects, and as a result of this change, the matcher scrolling behavior broke. The cause was a missed `.plus` rather than a `.minus` on a scroll event.