### PR TITLE
Fix section day change form

### DIFF
--- a/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
+++ b/csm_web/frontend/src/components/section/SpacetimeEditModal.tsx
@@ -107,7 +107,7 @@ const SpaceTimeEditModal = ({
               Day
               <select
                 className="form-select"
-                onChange={e => setDay(e.target.value)}
+                onChange={e => setDay(parseInt(e.target.value))}
                 required={!!isPermanent}
                 name="day"
                 disabled={!isPermanent}


### PR DESCRIPTION
See #439 for the original fix of the issue, but after merging in #429, there were additional errors due to the types used in the form (the state change failed to convert a string to an int type). This is a follow-up PR fixing that issue as well.