### PR TITLE
overridden typo fix

### DIFF
--- a/csm_web/scheduler/admin.py
+++ b/csm_web/scheduler/admin.py
@@ -895,11 +895,11 @@ class OverrideAdmin(BasePermissionModelAdmin):
     fields = (
         "date",
         "spacetime",
-        "overriden_spacetime",
+        "overridden_spacetime",
     )
     autocomplete_fields = (
         "spacetime",
-        "overriden_spacetime",
+        "overridden_spacetime",
     )
 
     list_filter = (
@@ -922,5 +922,5 @@ class OverrideAdmin(BasePermissionModelAdmin):
     def get_new_spacetime(self, obj: Override):
         """Format link to new spacetime object."""
         return get_admin_link_for(
-            obj.overriden_spacetime, "admin:scheduler_spacetime_change"
+            obj.overridden_spacetime, "admin:scheduler_spacetime_change"
         )

--- a/csm_web/scheduler/factories.py
+++ b/csm_web/scheduler/factories.py
@@ -218,8 +218,8 @@ class OverrideFactory(factory.django.DjangoModelFactory):
         date = evaluate_faker(
             factory.Faker(
                 "date_between_dates",
-                date_start=self.overriden_spacetime.section.mentor.course.enrollment_start.date(),
-                date_end=self.overriden_spacetime.section.mentor.course.valid_until,
+                date_start=self.overridden_spacetime.section.mentor.course.enrollment_start.date(),
+                date_end=self.overridden_spacetime.section.mentor.course.valid_until,
             )
         )
         return date + timedelta(

--- a/csm_web/scheduler/models.py
+++ b/csm_web/scheduler/models.py
@@ -528,14 +528,14 @@ class Override(ValidatingModel):
     spacetime = models.OneToOneField(
         Spacetime, on_delete=models.CASCADE, related_name="+"
     )
-    overriden_spacetime = models.OneToOneField(
+    overridden_spacetime = models.OneToOneField(
         Spacetime, related_name="_override", on_delete=models.CASCADE
     )
     date = models.DateField()
 
     def clean(self):
         super().clean()
-        if self.spacetime == self.overriden_spacetime:
+        if self.spacetime == self.overridden_spacetime:
             raise ValidationError("A spacetime cannot override itself")
         if self.spacetime.day_of_week != self.date.strftime("%A"):
             raise ValidationError(
@@ -548,7 +548,7 @@ class Override(ValidatingModel):
         return self.date < now.date()
 
     def __str__(self):
-        return f"Override for {self.overriden_spacetime.section} : {self.spacetime}"
+        return f"Override for {self.overridden_spacetime.section} : {self.spacetime}"
 
 
 class Matcher(ValidatingModel):

--- a/csm_web/scheduler/serializers.py
+++ b/csm_web/scheduler/serializers.py
@@ -350,11 +350,11 @@ class OverrideSerializer(serializers.ModelSerializer):
         spacetime = Spacetime.objects.create(
             **validated_data["spacetime"],
             day_of_week=DayOfWeekField.DAYS[validated_data["date"].weekday()],
-            duration=validated_data["overriden_spacetime"].duration,
+            duration=validated_data["overridden_spacetime"].duration,
         )
         return Override.objects.create(
             date=validated_data["date"],
-            overriden_spacetime=validated_data["overriden_spacetime"],
+            overridden_spacetime=validated_data["overridden_spacetime"],
             spacetime=spacetime,
         )
 
@@ -366,15 +366,15 @@ class OverrideSerializer(serializers.ModelSerializer):
         ]
         instance.spacetime.location = spacetime_data["location"]
         instance.spacetime.start_time = spacetime_data["start_time"]
-        instance.spacetime.duration = instance.overriden_spacetime.duration
+        instance.spacetime.duration = instance.overridden_spacetime.duration
         instance.spacetime.save()
         instance.save()
         return instance
 
     class Meta:
         model = Override
-        fields = ("location", "start_time", "date", "overriden_spacetime")
-        extra_kwargs = {"overriden_spacetime": {"required": False}}
+        fields = ("location", "start_time", "date", "overridden_spacetime")
+        extra_kwargs = {"overridden_spacetime": {"required": False}}
 
 
 class MatcherSerializer(serializers.ModelSerializer):

--- a/csm_web/scheduler/views/spacetime.py
+++ b/csm_web/scheduler/views/spacetime.py
@@ -114,7 +114,7 @@ class SpacetimeViewSet(viewsets.GenericViewSet):
                 status_code = status.HTTP_202_ACCEPTED
             else:  # create
                 serializer = OverrideSerializer(
-                    data={"overriden_spacetime": spacetime.pk, **request.data}
+                    data={"overridden_spacetime": spacetime.pk, **request.data}
                 )
                 status_code = status.HTTP_201_CREATED
             if serializer.is_valid():


### PR DESCRIPTION
This PR fixes the typo of `overriden_spacetime` to the `overridden_spacetime` field. This includes changes in the related files that use this field.