### PR TITLE
Prevent students from taking other students' attendances

### DIFF
--- a/csm_web/scheduler/views/student.py
+++ b/csm_web/scheduler/views/student.py
@@ -1,16 +1,14 @@
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils import timezone
-from scheduler.models import Attendance, SectionOccurrence
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
-import datetime
 
-from .utils import log_str, logger, get_object_or_error
 from ..models import Student
 from ..serializers import AttendanceSerializer, StudentSerializer
+from .utils import get_object_or_error, logger
 
 
 class StudentViewSet(viewsets.GenericViewSet):
@@ -28,13 +26,17 @@ class StudentViewSet(viewsets.GenericViewSet):
 
     @action(detail=True, methods=["patch"])
     def drop(self, request, pk=None):
+        """
+        Drops a student from a section.
+        Students can drop themselves, and coordinators can drop students from their course.
+        Mentors are unable to drop students from any course under any circumstances.
+        Deletes futures attendances for the dropped student.
+        """
         student = get_object_or_error(self.get_queryset(), pk=pk)
         is_coordinator = student.course.coordinator_set.filter(
             user=request.user
         ).exists()
         if student.user != request.user and not is_coordinator:
-            # Students can drop themselves, and Coordinators can drop students from their course
-            # Mentors CANNOT drop their own students, or anyone else for that matter
             raise PermissionDenied("You do not have permission to drop this student")
         student.active = False
         if is_coordinator:
@@ -42,10 +44,13 @@ class StudentViewSet(viewsets.GenericViewSet):
             if student.course.is_restricted and request.data.get("blacklisted", False):
                 student.course.whitelist.remove(student.user)
         student.save()
+
         logger.info(
-            f"<Drop> User {log_str(request.user)} dropped Section {log_str(student.section)} for Student user {log_str(student.user)}"
+            "<Drop> User %s dropped SEction %s for Student user %s",
+            request.user,
+            student.section,
+            student.user,
         )
-        # filter attendances and delete future attendances
         now = timezone.now().astimezone(timezone.get_default_timezone())
         num_deleted, _ = student.attendance_set.filter(
             Q(
@@ -54,20 +59,32 @@ class StudentViewSet(viewsets.GenericViewSet):
             )
         ).delete()
         logger.info(
-            f"<Drop> Deleted {num_deleted} attendances for user {log_str(student.user)} in Section {log_str(student.section)} after {now.date()}"
+            "<Drop> Deleted %s attendances for user %s in Section %s after %s",
+            num_deleted,
+            student.user,
+            student.section,
+            now.date(),
         )
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=["get", "put"])
     def attendances(self, request, pk=None):
+        """
+        Take attendance for a student.
+        """
         student = get_object_or_error(self.get_queryset(), pk=pk)
+        is_mentor = student.course.mentor_set.filter(user=request.user).exists()
         if request.method == "GET":
             return Response(
                 AttendanceSerializer(student.attendance_set.all(), many=True).data
             )
         # PUT
-        if student.user == self.request.user:
-            raise PermissionDenied("You cannot record your own attendance (nice try)")
+        if not is_mentor:
+            raise PermissionDenied(
+                "You cannot record your own attendance (nice try) or your friend's. But"
+                " seeing as you're familiar with our API Endpoints, you should apply to"
+                " work for us!"
+            )
         try:  # update
             attendance = student.attendance_set.get(pk=request.data["id"])
             serializer = AttendanceSerializer(
@@ -81,18 +98,26 @@ class StudentViewSet(viewsets.GenericViewSet):
             )
         except ObjectDoesNotExist:
             logger.error(
-                f"<Attendance:Failure> Could not record attendance for User {log_str(request.user)}, used non-existent attendance id {request.data['id']}"
+                (
+                    "<Attendance:FAILURE> Could not record attendance for User %s, used"
+                    " non-existent attendance id %s"
+                ),
+                request.user,
+                request.data["id"],
             )
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         if serializer.is_valid():
             attendance = serializer.save()
             logger.info(
-                f"<Attendance:Success> Attendance {log_str(attendance)} recorded for User {log_str(request.user)}"
+                "<Attendance:Success> Attednace %s taken for User %s",
+                attendance,
+                request.user,
             )
             return Response(status=status.HTTP_204_NO_CONTENT)
         logger.error(
-            f"<Attendance:Failure> Could not record attendance for User {log_str(request.user)}, errors: {serializer.errors}"
+            "<Attedance:FAILURE> Could not record attendance for User %s, errors %s",
+            request.user,
+            serializer.errors,
         )
         return Response(serializer.errors, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
-


### PR DESCRIPTION
Before, we only checked whether the requesting user was the student that the attendance was being taken for, so savvy students could take attendance for their friends by directly sending an API request. Now, only mentors for the specific section are able to take attendance.

Fixed pylint stuff for student.py