### PR TITLE
Page crashing when a section with no location is created - fixed

### DIFF
--- a/csm_web/frontend/src/components/course/CreateSectionModal.tsx
+++ b/csm_web/frontend/src/components/course/CreateSectionModal.tsx
@@ -46,6 +46,8 @@ export const CreateSectionModal = ({ courseId, closeModal, reloadSections }: Cre
    */
   const [capacity, setCapacity] = useState<string>("");
 
+  const [alertMessage, setAlertMessage] = useState<string | null>(null)
+
   /**
    * Create a new empty spacetime for the new section.
    */
@@ -87,10 +89,15 @@ export const CreateSectionModal = ({ courseId, closeModal, reloadSections }: Cre
     }
   };
 
-  /**
-   * Handle form submission.
-   */
+  const hasEmptyLocation = () => {
+    return spacetimes.some(spacetime => !spacetime.location?.trim());
+  };
+
+  
   const handleSubmit = (event: React.MouseEvent<HTMLButtonElement>): void => {
+
+    
+
     event.preventDefault();
     const data = {
       mentorEmail,
@@ -100,6 +107,9 @@ export const CreateSectionModal = ({ courseId, closeModal, reloadSections }: Cre
       courseId
     };
 
+    
+
+    
     createSectionMutation.mutate(data, {
       onSuccess: () => {
         closeModal();
@@ -110,6 +120,11 @@ export const CreateSectionModal = ({ courseId, closeModal, reloadSections }: Cre
 
   return (
     <Modal className="create-section-modal" closeModal={closeModal}>
+      {alertMessage && (
+  <div className="alert">
+    {alertMessage}
+  </div>
+)}
       <form id="create-section-form" className="csm-form">
         <div id="create-section-form-contents">
           <div id="non-spacetime-fields">
@@ -219,7 +234,7 @@ export const CreateSectionModal = ({ courseId, closeModal, reloadSections }: Cre
         <button className="secondary-btn" id="add-occurence-btn" onClick={appendSpacetime}>
           Add another occurence
         </button>
-        <button className="primary-btn" onClick={handleSubmit}>
+        <button className="primary-btn" onClick={handleSubmit} disabled={hasEmptyLocation()}>
           Submit
         </button>
       </div>


### PR DESCRIPTION
When a coordinator created a section without a location, because of a reason on the backend that I wasn't able to identify, the page was crashing. Therefore, I disabled the submit button until the coordinator inputs a location in order to prevent the above mentioned error from happening. 