### PR TITLE
Fix pylint/pre-commit configuration

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,12 @@ jobs:
       - name: Parse Python version from runtime.txt
         run: |
           sed 's/[^0-9.]//g' runtime.txt | head > .python-version
+      - name: Set up Pylint pre-commit
+        run: |
+          # remove all instances of docker compose exec; github CI doesn't use docker
+          sed -E 's/docker compose exec -T \w+\s*//g' .pre-commit-config.yaml > .pre-commit-config-ci.yaml
+          mv .pre-commit-config-ci.yaml .pre-commit-config.yaml
+          touch .env  # ensure .env file exists
       - name: Set up Python
         uses: actions/setup-python@v4
       - name: Install Poetry
@@ -29,7 +35,7 @@ jobs:
           installer-parallel: true
       - name: Install dependencies with Poetry
         run: |
-          poetry install --no-root --with=dev --no-interaction --no-ansi
+          poetry install --no-root --with=prod --no-interaction --no-ansi
           # add virtual environment to path for future steps
           echo $(poetry env info --path)/bin >> $GITHUB_PATH
       - name: Install npm dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     hooks:
       - id: pylint
         name: pylint
-        entry: pylint
+        entry: docker compose exec -T django pylint
         language: system
         types: [python]
         args: [


### PR DESCRIPTION
With the changes in #457, `psycopg2-binary` is no longer installed by default in development systems (it causes a lot of setup issues). However, `pylint_django` requires a working Django backend in order to provide linting, which now errors due to a lack of the `psycopg2` package.

This PR modifies the pre-commit configuration to run `pylint` in Docker instead, as the Docker container has all of the backend dependencies installed. The pre-commit configuration also still had the old `--with=dev` flag, which is now swapped to `--with=prod`.