### PR TITLE
Update docker-compose to allow migrations to be created in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,10 @@ services:
         source: ./
         target: /opt/csm_web
         read_only: true
+      # output from migrations
+      - type: bind
+        source: ./csm_web/scheduler/migrations/
+        target: /opt/csm_web/csm_web/scheduler/migrations/
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Currently, running `docker compose exec django makemigrations` will error, since the Django file system in Docker is read-only. This PR modifies the bind mounts to allow writes to the migrations folder. (The migrations folder in the frontend app is not included here, since we only make database changes within the `scheduler` app.)