### PR TITLE
Fix queries for counts in course data export

### DIFF
--- a/csm_web/scheduler/admin.py
+++ b/csm_web/scheduler/admin.py
@@ -715,7 +715,9 @@ class CourseAdmin(BasePermissionModelAdmin):
     @admin.display(description="Section count")
     def get_section_count(self, obj: Course):
         """Retrieve the number of sections associated with this course."""
-        return obj.mentor_set.count()  # one-to-one between mentor objects and sections
+        # only count mentors that have a section associated with it;
+        # at most one section can be associated with a given mentor object
+        return obj.mentor_set.filter(~Q(section=None)).count()
 
     @admin.display(description="Student count")
     def get_student_count(self, obj: Course):

--- a/csm_web/scheduler/views/export.py
+++ b/csm_web/scheduler/views/export.py
@@ -365,18 +365,20 @@ def prepare_course_data(
         export_headers.append("Course title")
     if "num_sections" in fields:
         course_queryset = course_queryset.annotate(
-            num_sections=Count("mentor__section")
+            num_sections=Count("mentor__section", distinct=True)
         )
         export_fields.append("num_sections")
         export_headers.append("Number of sections")
     if "num_students" in fields:
         course_queryset = course_queryset.annotate(
-            num_students=Count("mentor__section__students")
+            num_students=Count("mentor__section__students", distinct=True)
         )
         export_fields.append("num_students")
         export_headers.append("Number of students")
     if "num_mentors" in fields:
-        course_queryset = course_queryset.annotate(num_mentors=Count("mentor"))
+        course_queryset = course_queryset.annotate(
+            num_mentors=Count("mentor", distinct=True)
+        )
         export_fields.append("num_mentors")
         export_headers.append("Number of mentors")
 


### PR DESCRIPTION
Prior, due to traversals through many-to-many and many-to-one field relations, the counts for the number of students/mentors/sections were messed up. This has now been fixed by ensuring that the counts are for distinct objects.

The Django admin console section count has also been fixed to actually look at the number of sections, since now mentors can be associated with no section.